### PR TITLE
Update compatability issue URL in game_list_frame.cpp

### DIFF
--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -98,7 +98,8 @@ GameListFrame::GameListFrame(std::shared_ptr<GameInfoClass> game_info_get,
 
     connect(this, &QTableWidget::cellClicked, this, [=, this](int row, int column) {
         if (column == 2 && m_game_info->m_games[row].compatibility.issue_number != "") {
-            auto url_issues = "https://github.com/shadps4-emu/shadps4-game-compatibility/issues/";
+            auto url_issues = 
+                "https://github.com/shadps4-compatibility/shadps4-game-compatibility/issues/";
             QDesktopServices::openUrl(
                 QUrl(url_issues + m_game_info->m_games[row].compatibility.issue_number));
         } else if (column == 10) {


### PR DESCRIPTION
The URL for the compatability issues has changed in the upstream repo. 
This PR adapts the URL in this fork as well to fix the 404 page that is currently displayed when clicking on the compatability issue cell in the game list.