### PR TITLE
fix: persist ShadPath to QSettings so PKG installer directory is remembered across sessions

### DIFF
--- a/src/qt_gui/compatibility_info.h
+++ b/src/qt_gui/compatibility_info.h
@@ -107,6 +107,8 @@ public:
 
         // Persist to disk
         QSettings settings("shadPS4", "Emulator");
+        settings.setValue("ShadPath", QString::fromStdString(path));
+        settings.sync();
     }
     QList<int> LoadDockWidgetSizes();
     void SaveDockWidgetSizes(const QList<int>& sizes);


### PR DESCRIPTION
## Problem

Every time the user clicks "Install PKG", they must re-select the PKG installer directory — even if they chose it in a previous session.

## Root Cause

`SetShadPath()` in `src/qt_gui/compatibility_info.h` creates a `QSettings` object and updates the in-memory `m_shadPath`, but **never calls `setValue()` or `sync()`** to persist the value to disk/registry. The comment on line 108 even says `// Persist to disk`, but the implementation was incomplete.

On restart, `GetShadPath()` reads from `QSettings` and finds nothing, returning an empty string. This forces the user to re-select the folder every time.

## Fix

Added the missing two lines:
```cpp
settings.setValue("ShadPath", QString::fromStdString(path));
settings.sync();
```

The key name `"ShadPath"` and the QSettings constructor params `("shadPS4", "Emulator")` match exactly what `GetShadPath()` already uses to read the value back.

## Testing

- First launch (no saved path) → prompts for directory ✓
- Select directory, restart → path remembered, no prompt ✓
- Clear path, restart → prompts again ✓
- Change directory, restart → new path remembered ✓
- In-memory cache still works (no regression) ✓