### PR TITLE
i18n: complete zh-CN translation coverage (zh_CN.ts)

### DIFF
--- a/src/qt_gui/translations/zh_CN.ts
+++ b/src/qt_gui/translations/zh_CN.ts
@@ -65,7 +65,7 @@
       <translation>没有选择文件。</translation>
     </message>
     <message>
-      <source>You can delete the cheats you don&apos;t want after downloading them.</source>
+      <source>You can delete the cheats you don't want after downloading them.</source>
       <translation>您可以在下载后删除不想要的作弊码。</translation>
     </message>
     <message>
@@ -237,12 +237,20 @@
       <translation>名称：</translation>
     </message>
     <message>
-      <source>Can&apos;t apply cheats before the game is started</source>
+      <source>Can't apply cheats before the game is started</source>
       <translation>在游戏启动之前无法应用作弊码。</translation>
     </message>
     <message>
       <source>Close</source>
       <translation>关闭</translation>
+    </message>
+    <message>
+      <source>Cheats/Patches are experimental.\\nUse with caution.\\n\\nDownload cheats individually by selecting the repository and clicking the download button.\\nIn the Patches tab, you can download all patches at once, choose which ones you want to use, and save your selection.\\n\\nSince we do not develop the Cheats/Patches,\\nplease report issues to the cheat author.\\n\\nCreated a new cheat? Visit:\\n</source>
+      <translation>作弊码/补丁是实验性的，\n请小心使用。\n\n通过选择存储库并点击下载按钮来逐个下载作弊码。\n在"补丁"选项卡中，您可以一次性下载所有补丁，选择要使用的补丁并保存选择。\n\n由于我们不开发作弊码/补丁，\n请将问题报告给作弊码/补丁的作者。\n\n创建了新的作弊码/补丁？欢迎访问：\n</translation>
+    </message>
+    <message>
+      <source>Do you want to delete the selected file?\\n%1</source>
+      <translation>确定要删除选定的文件吗？\n%1</translation>
     </message>
   </context>
   <context>
@@ -350,6 +358,38 @@
     <message>
       <source>Failed to create the update script file</source>
       <translation>无法创建更新脚本文件</translation>
+    </message>
+    <message>
+      <source>Network error: %1</source>
+      <translation>网络错误：%1</translation>
+    </message>
+    <message>
+      <source>No Qt asset found for this Revert release and platform.</source>
+      <translation>此Revert发布版未找到适用于此平台的Qt资源。</translation>
+    </message>
+    <message>
+      <source>No Shadlix release found.</source>
+      <translation>未找到Shadlix发布版。</translation>
+    </message>
+    <message>
+      <source>No releases found for update channel:</source>
+      <translation>此更新频道未找到发布版：</translation>
+    </message>
+    <message>
+      <source>Not enough successful workflow runs for Revert.</source>
+      <translation>Revert没有足够多的成功工作流运行记录。</translation>
+    </message>
+    <message>
+      <source>Press OK to install or Cancel to exit.</source>
+      <translation>按确定安装，或按取消退出。</translation>
+    </message>
+    <message>
+      <source>Select a Revert Build</source>
+      <translation>选择一个Revert构建版本</translation>
+    </message>
+    <message>
+      <source>The update has been downloaded.</source>
+      <translation>更新已下载。</translation>
     </message>
   </context>
   <context>
@@ -595,7 +635,7 @@
     </message>
     <message>
       <source>ID: </source>
-      <translation>ID:  </translation>
+      <translation>ID：</translation>
     </message>
     <message>
       <source>Default Controller Selected</source>
@@ -624,6 +664,34 @@
     <message>
       <source>BLUE</source>
       <translation>蓝</translation>
+    </message>
+    <message>
+      <source>Cannot bind any unique input more than once. Duplicate inputs mapped to the following buttons:\n\n%1</source>
+      <translation>每个输入只能绑定一次。以下按键存在重复绑定：\n\n%1</translation>
+    </message>
+    <message>
+      <source>Left Stick Deadzone</source>
+      <translation>左摇杆死区</translation>
+    </message>
+    <message>
+      <source>Min Deadzone (def:2 max:127)</source>
+      <translation>最小死区（默认2 最大127）</translation>
+    </message>
+    <message>
+      <source>Max Deadzone (def:127 max:127)</source>
+      <translation>最大死区（默认127 最大127）</translation>
+    </message>
+    <message>
+      <source>Right Stick Deadzone</source>
+      <translation>右摇杆死区</translation>
+    </message>
+    <message>
+      <source>No gamepads detected</source>
+      <translation>未检测到手柄</translation>
+    </message>
+    <message>
+      <source>Default controller not connected</source>
+      <translation>默认手柄未连接</translation>
     </message>
   </context>
   <context>
@@ -672,6 +740,18 @@
       <source>Reset to Default</source>
       <translation>重置为默认</translation>
     </message>
+    <message>
+      <source>Save</source>
+      <translation>保存</translation>
+    </message>
+    <message>
+      <source>Cancel</source>
+      <translation>取消</translation>
+    </message>
+    <message>
+      <source>Default</source>
+      <translation>默认</translation>
+    </message>
   </context>
   <context>
     <name>ElfViewer</name>
@@ -693,29 +773,6 @@
     <message>
       <source>Loading...</source>
       <translation>加载中...</translation>
-    </message>
-  </context>
-  <context>
-    <name>GameInstallDialog</name>
-    <message>
-      <source>shadPS4 - Choose directory</source>
-      <translation>shadPS4 - 选择文件目录</translation>
-    </message>
-    <message>
-      <source>Directory to install games</source>
-      <translation>要安装游戏的目录</translation>
-    </message>
-    <message>
-      <source>Browse</source>
-      <translation>浏览</translation>
-    </message>
-    <message>
-      <source>Error</source>
-      <translation>错误</translation>
-    </message>
-    <message>
-      <source>Directory to install DLC</source>
-      <translation>安装 DLC 的目录</translation>
     </message>
   </context>
   <context>
@@ -959,7 +1016,7 @@
       <translation>删除 %1</translation>
     </message>
     <message>
-      <source>Are you sure you want to delete %1&apos;s %2 directory?</source>
+      <source>Are you sure you want to delete %1's %2 directory?</source>
       <translation>您确定要删除 %1 的%2目录？</translation>
     </message>
     <message>
@@ -1045,6 +1102,106 @@
     <message>
       <source>Delete game-specific settings?</source>
       <translation>删除游戏特定设置？</translation>
+    </message>
+    <message>
+      <source>Are you sure you want to delete %1's %2?</source>
+      <translation>确定要删除 %1 的 %2 吗？</translation>
+    </message>
+    <message>
+      <source>Boot Game Detached</source>
+      <translation>分离模式启动</translation>
+    </message>
+    <message>
+      <source>Configure game-specific settings</source>
+      <translation>配置游戏特定设置</translation>
+    </message>
+    <message>
+      <source>Confirm Deletion</source>
+      <translation>确认删除</translation>
+    </message>
+    <message>
+      <source>Create game-specific settings from global settings</source>
+      <translation>从全局设置创建游戏特定设置</translation>
+    </message>
+    <message>
+      <source>Custom Configuration...</source>
+      <translation>自定义配置...</translation>
+    </message>
+    <message>
+      <source>Delete Game-specific settings?</source>
+      <translation>删除游戏特定设置？</translation>
+    </message>
+    <message>
+      <source>Delete Shader Cache</source>
+      <translation>删除着色器缓存</translation>
+    </message>
+    <message>
+      <source>Delete game-specific settings</source>
+      <translation>删除游戏特定设置</translation>
+    </message>
+    <message>
+      <source>Failed to launch game in detached mode.</source>
+      <translation>分离模式启动游戏失败。</translation>
+    </message>
+    <message>
+      <source>Invalid game path.</source>
+      <translation>游戏路径无效。</translation>
+    </message>
+    <message>
+      <source>Launch with game specific configs (default)</source>
+      <translation>使用游戏特定配置启动（默认）</translation>
+    </message>
+    <message>
+      <source>Launch with global config only</source>
+      <translation>仅使用全局配置启动</translation>
+    </message>
+    <message>
+      <source>Launch...</source>
+      <translation>启动...</translation>
+    </message>
+    <message>
+      <source>Mods Folder</source>
+      <translation>Mod文件夹</translation>
+    </message>
+    <message>
+      <source>Mods folder not found. Expected paths: %1</source>
+      <translation>未找到Mod文件夹。预期路径：%1</translation>
+    </message>
+    <message>
+      <source>Open Custom Configuration Folder</source>
+      <translation>打开自定义配置文件夹</translation>
+    </message>
+    <message>
+      <source>Open Mods Folder</source>
+      <translation>打开Mod文件夹</translation>
+    </message>
+    <message>
+      <source>Shader Cache</source>
+      <translation>着色器缓存</translation>
+    </message>
+    <message>
+      <source>Submit a report</source>
+      <translation>提交报告</translation>
+    </message>
+    <message>
+      <source>This game does not have any saved Shader Cache to delete!</source>
+      <translation>此游戏没有已保存的着色器缓存可删除！</translation>
+    </message>
+    <message>
+      <source>Update Folder</source>
+      <translation>更新文件夹</translation>
+    </message>
+    <message>
+      <source>Update database</source>
+      <translation>更新数据库</translation>
+    </message>
+    <message>
+      <source>Update folder not found for this game.</source>
+      <translation>未找到此游戏的更新文件夹。</translation>
+    </message>
+    <message>
+      <source>View report</source>
+      <translation>查看报告</translation>
     </message>
   </context>
   <context>
@@ -1156,6 +1313,30 @@
       <source>Waiting for inputs</source>
       <translation>正在等待输入</translation>
     </message>
+    <message>
+      <source>Cannot bind any unique input more than once. Duplicate inputs mapped to the following buttons:\n\n%1</source>
+      <translation>每个输入只能绑定一次。以下按键存在重复绑定：\n\n%1</translation>
+    </message>
+    <message>
+      <source>Screenshot</source>
+      <translation>截图</translation>
+    </message>
+    <message>
+      <source>Volume Up</source>
+      <translation>音量加</translation>
+    </message>
+    <message>
+      <source>Volume Down</source>
+      <translation>音量减</translation>
+    </message>
+    <message>
+      <source>Volume Mute</source>
+      <translation>静音</translation>
+    </message>
+    <message>
+      <source>Toggle Mouse to Touchpad Emulation</source>
+      <translation>切换鼠标触控板模拟</translation>
+    </message>
   </context>
   <context>
     <name>KBMSettings</name>
@@ -1237,7 +1418,7 @@
     </message>
     <message>
       <source>note: click Help Button/Special Keybindings for more information</source>
-      <translation>注意：点击帮助按钮 -> 获取更多关于映射特殊键位的信息</translation>
+      <translation>注意：点击帮助按钮 -&gt; 获取更多关于映射特殊键位的信息</translation>
     </message>
     <message>
       <source>Face Buttons</source>
@@ -1355,6 +1536,34 @@
       <source>Touchpad Right</source>
       <translation>触摸板右侧</translation>
     </message>
+    <message>
+      <source>L1</source>
+      <translation>L1</translation>
+    </message>
+    <message>
+      <source>L2</source>
+      <translation>L2</translation>
+    </message>
+    <message>
+      <source>R1</source>
+      <translation>R1</translation>
+    </message>
+    <message>
+      <source>R2</source>
+      <translation>R2</translation>
+    </message>
+    <message>
+      <source>L3</source>
+      <translation>L3</translation>
+    </message>
+    <message>
+      <source>R3</source>
+      <translation>R3</translation>
+    </message>
+    <message>
+      <source>Cannot bind any unique input more than once. Duplicate inputs mapped to the following buttons:\n\n%1</source>
+      <translation>每个输入只能绑定一次。以下按键存在重复绑定：\n\n%1</translation>
+    </message>
   </context>
   <context>
     <name>LogPresetsDialog</name>
@@ -1389,6 +1598,14 @@
     <message>
       <source>Load the selected preset</source>
       <translation>加载选中的预设</translation>
+    </message>
+    <message>
+      <source>+</source>
+      <translation>+</translation>
+    </message>
+    <message>
+      <source>-</source>
+      <translation>-</translation>
     </message>
   </context>
   <context>
@@ -1652,6 +1869,214 @@
     <message>
       <source>Customize Hotkeys</source>
       <translation>自定义快捷键</translation>
+    </message>
+    <message>
+      <source>Are you sure you want to delete %1's Shader Cache?</source>
+      <translation>确定要删除 %1 的着色器缓存吗？</translation>
+    </message>
+    <message>
+      <source>BP Boot</source>
+      <translation>大屏启动</translation>
+    </message>
+    <message>
+      <source>BigPicture</source>
+      <translation>大屏模式</translation>
+    </message>
+    <message>
+      <source>Boot on Big Picture</source>
+      <translation>以大屏模式启动</translation>
+    </message>
+    <message>
+      <source>Boot on GameHub</source>
+      <translation>以游戏中心模式启动</translation>
+    </message>
+    <message>
+      <source>Cannot restart: no stored game path.</source>
+      <translation>无法重启：未存储游戏路径。</translation>
+    </message>
+    <message>
+      <source>Cinema View</source>
+      <translation>影院视图</translation>
+    </message>
+    <message>
+      <source>Clear Custom Background</source>
+      <translation>清除自定义背景</translation>
+    </message>
+    <message>
+      <source>Could not find the emulator executable</source>
+      <translation>找不到模拟器可执行文件</translation>
+    </message>
+    <message>
+      <source>Customize Toolbar</source>
+      <translation>自定义工具栏</translation>
+    </message>
+    <message>
+      <source>Delete Shader Cache</source>
+      <translation>删除着色器缓存</translation>
+    </message>
+    <message>
+      <source>ELF files (*.bin *.elf *.oelf *.self)</source>
+      <translation>ELF文件 (*.bin *.elf *.oelf *.self)</translation>
+    </message>
+    <message>
+      <source>Enable Theme Colors</source>
+      <translation>启用主题配色</translation>
+    </message>
+    <message>
+      <source>Error</source>
+      <translation>错误</translation>
+    </message>
+    <message>
+      <source>Failed to launch game in detached mode.</source>
+      <translation>分离模式启动游戏失败。</translation>
+    </message>
+    <message>
+      <source>Failed to start game process.</source>
+      <translation>启动游戏进程失败。</translation>
+    </message>
+    <message>
+      <source>GUI Style:</source>
+      <translation>界面样式：</translation>
+    </message>
+    <message>
+      <source>Game Log</source>
+      <translation>游戏日志</translation>
+    </message>
+    <message>
+      <source>GameHub</source>
+      <translation>游戏中心</translation>
+    </message>
+    <message>
+      <source>Games Directory</source>
+      <translation>游戏目录</translation>
+    </message>
+    <message>
+      <source>Hide Log</source>
+      <translation>隐藏日志</translation>
+    </message>
+    <message>
+      <source>Hotkeys</source>
+      <translation>快捷键</translation>
+    </message>
+    <message>
+      <source>IPC client not initialized.</source>
+      <translation>IPC客户端未初始化。</translation>
+    </message>
+    <message>
+      <source>Images (*.png *.jpg *.jpeg *.bmp)</source>
+      <translation>图片 (*.png *.jpg *.jpeg *.bmp)</translation>
+    </message>
+    <message>
+      <source>Install PKG</source>
+      <translation>安装PKG</translation>
+    </message>
+    <message>
+      <source>Invalid game index.</source>
+      <translation>游戏索引无效。</translation>
+    </message>
+    <message>
+      <source>Invalid launch path.</source>
+      <translation>启动路径无效。</translation>
+    </message>
+    <message>
+      <source>Let you Boot Game with selected Version</source>
+      <translation>使用选定版本启动游戏</translation>
+    </message>
+    <message>
+      <source>Mod Manager</source>
+      <translation>Mod管理器</translation>
+    </message>
+    <message>
+      <source>Mods Manager</source>
+      <translation>Mod管理器</translation>
+    </message>
+    <message>
+      <source>No game is currently running.</source>
+      <translation>当前没有正在运行的游戏。</translation>
+    </message>
+    <message>
+      <source>No game path provided.</source>
+      <translation>未提供游戏路径。</translation>
+    </message>
+    <message>
+      <source>No game selected.</source>
+      <translation>未选择游戏。</translation>
+    </message>
+    <message>
+      <source>Patches Downloaded Successfully!\nAll patches available </source>
+      <translation>补丁下载成功！\n所有可用补丁</translation>
+    </message>
+    <message>
+      <source>Restart Game</source>
+      <translation>重启游戏</translation>
+    </message>
+    <message>
+      <source>Select Background Image</source>
+      <translation>选择背景图片</translation>
+    </message>
+    <message>
+      <source>Separator</source>
+      <translation>分隔符</translation>
+    </message>
+    <message>
+      <source>Set Custom Background...</source>
+      <translation>设置自定义背景...</translation>
+    </message>
+    <message>
+      <source>Shader Cache</source>
+      <translation>着色器缓存</translation>
+    </message>
+    <message>
+      <source>Shader Cache Invalid</source>
+      <translation>着色器缓存无效</translation>
+    </message>
+    <message>
+      <source>Show Log</source>
+      <translation>显示日志</translation>
+    </message>
+    <message>
+      <source>Show Welcome On Launch</source>
+      <translation>启动时显示欢迎页</translation>
+    </message>
+    <message>
+      <source>Style/Search/Size</source>
+      <translation>样式/搜索/大小</translation>
+    </message>
+    <message>
+      <source>The shader cache for %1 is invalid.\n\n</source>
+      <translation>%1 的着色器缓存无效。\n\n</translation>
+    </message>
+    <message>
+      <source>This Enables Flow of Icons So its always ON</source>
+      <translation>启用图标流式布局（始终保持开启）</translation>
+    </message>
+    <message>
+      <source>This game does not have any saved Shader Cache to delete.</source>
+      <translation>此游戏没有已保存的着色器缓存可删除。</translation>
+    </message>
+    <message>
+      <source>Unknown Widget</source>
+      <translation>未知组件</translation>
+    </message>
+    <message>
+      <source>Update</source>
+      <translation>更新</translation>
+    </message>
+    <message>
+      <source>Use Selected Version</source>
+      <translation>使用选定版本</translation>
+    </message>
+    <message>
+      <source>Version</source>
+      <translation>版本</translation>
+    </message>
+    <message>
+      <source>Version shadPS4</source>
+      <translation>shadPS4 版本</translation>
+    </message>
+    <message>
+      <source>Pause Game When Unfocused</source>
+      <translation>失去焦点时暂停游戏</translation>
     </message>
   </context>
   <context>
@@ -1937,15 +2362,15 @@
       <translation>将鼠标指针指向选项以显示其描述。</translation>
     </message>
     <message>
-      <source>Console Language:\nSets the language that the PS4 game uses.\nIt&apos;s recommended to set this to a language the game supports, which will vary by region.</source>
+      <source>Console Language:\nSets the language that the PS4 game uses.\nIt's recommended to set this to a language the game supports, which will vary by region.</source>
       <translation>主机语言：\n设置 PS4 游戏中使用的语言。\n建议设置为支持的语言，这将因地区而异。</translation>
     </message>
     <message>
-      <source>Emulator Language:\nSets the language of the emulator&apos;s user interface.</source>
+      <source>Emulator Language:\nSets the language of the emulator's user interface.</source>
       <translation>模拟器语言：\n设置模拟器用户界面的语言。</translation>
     </message>
     <message>
-      <source>Show Splash Screen:\nShows the game&apos;s splash screen (a special image) while the game is starting.</source>
+      <source>Show Splash Screen:\nShows the game's splash screen (a special image) while the game is starting.</source>
       <translation>显示启动画面：\n在游戏启动时显示游戏的启动画面（特殊图像）。</translation>
     </message>
     <message>
@@ -1953,7 +2378,7 @@
       <translation>启用 Discord Rich Presence：\n在您的 Discord 个人资料上显示模拟器图标和相关信息。</translation>
     </message>
     <message>
-      <source>Username:\nSets the PS4&apos;s account username, which may be displayed by some games.</source>
+      <source>Username:\nSets the PS4's account username, which may be displayed by some games.</source>
       <translation>用户名：\n设置 PS4 帐户的用户名，某些游戏中可能会显示此名称。</translation>
     </message>
     <message>
@@ -1965,8 +2390,8 @@
       <translation>日志类型：\n设置日志窗口输出的同步方式以提高性能。可能会对模拟产生不良影响。</translation>
     </message>
     <message>
-      <source>Log Filter:\nFilters the log to only print specific information.\nExamples: &quot;Core:Trace&quot; &quot;Lib.Pad:Debug Common.Filesystem:Error&quot; &quot;*:Critical&quot;\nLevels: Trace, Debug, Info, Warning, Error, Critical - in this order, a specific level silences all levels preceding it in the list and logs every level after it.</source>
-      <translation>日志过滤器：\n过滤日志，仅打印特定信息。\n例如：&quot;Core:Trace&quot; &quot;Lib.Pad:Debug Common.Filesystem:Error&quot; &quot;*:Critical&quot; 级别: Trace, Debug, Info, Warning, Error, Critical - 按此顺序，特定级别将静默列表中所有先前的级别，并记录所有后续级别。</translation>
+      <source>Log Filter:\nFilters the log to only print specific information.\nExamples: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical"\nLevels: Trace, Debug, Info, Warning, Error, Critical - in this order, a specific level silences all levels preceding it in the list and logs every level after it.</source>
+      <translation>日志过滤器：\n过滤日志，仅打印特定信息。\n例如："Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" 级别: Trace, Debug, Info, Warning, Error, Critical - 按此顺序，特定级别将静默列表中所有先前的级别，并记录所有后续级别。</translation>
     </message>
     <message>
       <source>Update:\nRelease: Official versions released every month that may be very outdated, but are more reliable and tested.\nNightly: Development versions that have all the latest features and fixes, but may contain bugs and are less stable.</source>
@@ -1993,7 +2418,7 @@
       <translation>光标隐藏闲置时长：\n光标自动隐藏之前的闲置时长。</translation>
     </message>
     <message>
-      <source>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable &quot;Update Compatibility On Startup&quot; to get up-to-date information.</source>
+      <source>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</source>
       <translation>显示兼容性数据：\n在列表视图中显示游戏兼容性信息。启用“启动时更新兼容性数据库”以获取最新信息。</translation>
     </message>
     <message>
@@ -2017,7 +2442,7 @@
       <translation>始终</translation>
     </message>
     <message>
-      <source>Graphics Device:\nOn multiple GPU systems, select the GPU the emulator will use from the drop down list,\nor select &quot;Auto Select&quot; to automatically determine it.</source>
+      <source>Graphics Device:\nOn multiple GPU systems, select the GPU the emulator will use from the drop down list,\nor select "Auto Select" to automatically determine it.</source>
       <translation>图形设备：\n在具有多个 GPU 的系统中，从下拉列表中选择要使用的 GPU，\n或者选择“自动选择”由模拟器决定。</translation>
     </message>
     <message>
@@ -2201,7 +2626,7 @@
       <translation>本地用户文件夹</translation>
     </message>
     <message>
-      <source>Create Portable User Folder from Common User Folder</source>
+      <source>Create Portable User Folder from Global AppData Folder</source>
       <translation>从公共用户文件夹创建本地用户文件夹</translation>
     </message>
     <message>
@@ -2249,7 +2674,7 @@
       <translation>启用控制器后台输入：\n允许 shadPS4 在游戏窗口不在焦点时检测控制器输入。</translation>
     </message>
     <message>
-      <source>Crash Diagnostics:\nCreates a .yaml file with info about the Vulkan state at the time of crashing.\nUseful for debugging &apos;Device lost&apos; errors. If you have this enabled, you should enable Host AND Guest Debug Markers.\nYou need Vulkan Validation Layers enabled and the Vulkan SDK for this to work.</source>
+      <source>Crash Diagnostics:\nCreates a .yaml file with info about the Vulkan state at the time of crashing.\nUseful for debugging 'Device lost' errors. If you have this enabled, you should enable Host AND Guest Debug Markers.\nYou need Vulkan Validation Layers enabled and the Vulkan SDK for this to work.</source>
       <translation>崩溃诊断：\n创建一个包含崩溃时 Vulkan 状态的 .yaml 文件。\n对于调试“Device lost”错误很有用。如果您启用了此功能，您应该同时启用 Host 和 Guest 调试标记。\n此功能在 Intel 显卡上不可用。\n您需要启用 Vulkan 验证层和 Vulkan SDK 才能使用此功能。</translation>
     </message>
     <message>
@@ -2257,7 +2682,7 @@
       <translation>启用日志记录</translation>
     </message>
     <message>
-      <source>Enable Logging:\nEnables logging.\nDo not change this if you do not know what you&apos;re doing!\nWhen asking for help, make sure this setting is ENABLED.</source>
+      <source>Enable Logging:\nEnables logging.\nDo not change this if you do not know what you're doing!\nWhen asking for help, make sure this setting is ENABLED.</source>
       <translation>启用日志记录：\n开启日志记录功能。\n若不了解相关操作，请勿修改此设置！\n寻求帮助时，请确保此项设置处于启用状态。</translation>
     </message>
     <message>
@@ -2285,7 +2710,7 @@
       <translation>选择 DLC 文件夹</translation>
     </message>
     <message>
-      <source>Present Mode:\nConfigures how video output will be presented to your screen.\n\nMailbox: Frames synchronize with your screen&apos;s refresh rate. New frames will replace any pending frames. Reduces latency but may skip frames if running behind.\nFifo: Frames synchronize with your screen&apos;s refresh rate. New frames will be queued behind pending frames. Ensures all frames are presented but may increase latency.\nImmediate: Frames immediately present to your screen when ready. May result in tearing.</source>
+      <source>Present Mode:\nConfigures how video output will be presented to your screen.\n\nMailbox: Frames synchronize with your screen's refresh rate. New frames will replace any pending frames. Reduces latency but may skip frames if running behind.\nFifo: Frames synchronize with your screen's refresh rate. New frames will be queued behind pending frames. Ensures all frames are presented but may increase latency.\nImmediate: Frames immediately present to your screen when ready. May result in tearing.</source>
       <translation>呈现模式：\n配置视频输出到屏幕的显示方式。\n\n信箱模式：帧画面与屏幕刷新率同步。新帧将替换所有待处理帧，可降低延迟但落后时可能跳帧。\n先进先出：帧画面与屏幕刷新率同步。新帧将排列在待处理帧之后，确保所有帧都被呈现但可能增加延迟。\n即时模式：帧画面准备就绪后立即显示于屏幕，可能导致画面撕裂。</translation>
     </message>
     <message>
@@ -2341,7 +2766,7 @@
       <translation>在列表中显示游戏大小：\n开启后，游戏列表将会显示每个游戏的安装容量。</translation>
     </message>
     <message>
-      <source>Enable Motion Controls:\nWhen enabled it will use the controller&apos;s motion control if supported.</source>
+      <source>Enable Motion Controls:\nWhen enabled it will use the controller's motion control if supported.</source>
       <translation>启用体感控制：\n启用后，若控制器支持，将使用其体感功能。</translation>
     </message>
     <message>
@@ -2361,11 +2786,11 @@
       <translation>启用 Devkit 开发机模式</translation>
     </message>
     <message>
-      <source>Set &quot;PSN signed-in&quot; to True</source>
+      <source>Set "PSN signed-in" to True</source>
       <translation>将“PSN登录状态”设为“已登录”</translation>
     </message>
     <message>
-      <source>Set &quot;Network Connected&quot; to True</source>
+      <source>Set "Network Connected" to True</source>
       <translation>将“网络连接状态”设为“已连接”</translation>
     </message>
     <message>
@@ -2428,6 +2853,628 @@
       <source>Audio Device (DS4 speaker)</source>
       <translation>音频设备（DS4 手柄扬声器）</translation>
     </message>
+    <message>
+      <source>%1 already exists. Overwrite with global folder data?</source>
+      <translation>%1 已存在。是否用全局文件夹数据覆盖？</translation>
+    </message>
+    <message>
+      <source>%1 already exists. Overwrite with portable folder data?</source>
+      <translation>%1 已存在。是否用便携文件夹数据覆盖？</translation>
+    </message>
+    <message>
+      <source>%1 successfully created - Relaunch Emulator to Activate</source>
+      <translation>%1 创建成功 - 重新启动模拟器以激活</translation>
+    </message>
+    <message>
+      <source>%1 successfully created - Relaunch Emulator to Configure</source>
+      <translation>%1 创建成功 - 重新启动模拟器以配置</translation>
+    </message>
+    <message>
+      <source>Add:\\nAdd a folder to the list.</source>
+      <translation>添加：
+向列表中添加文件夹。</translation>
+    </message>
+    <message>
+      <source>All Cores</source>
+      <translation>全部核心</translation>
+    </message>
+    <message>
+      <source>Background Image:\\nControl the opacity of the game background image.</source>
+      <translation>背景图片：\n控制游戏背景图片的不透明度。</translation>
+    </message>
+    <message>
+      <source>Browse:\\nBrowse for a folder to set as the DLC path.</source>
+      <translation>浏览：
+选择要设置为DLC路径的文件夹。</translation>
+    </message>
+    <message>
+      <source>Browse:\\nBrowse for a folder to set as the save data path.</source>
+      <translation>浏览：
+选择要设置为存档数据路径的文件夹。</translation>
+    </message>
+    <message>
+      <source>CPU Configuration:\nConfigure CPU core usage for better performance or compatibility.\n\nAll Cores: Use all available CPU cores (default).\nEfficient Cores: Use only efficient/power-saving CPU cores.\nCustom Cores: Manually specify which CPU cores to use (comma-separated numbers).\n\nNote: Changes require emulator restart to take effect.</source>
+      <translation>CPU配置：\n配置CPU核心使用方式以获得更好的性能或兼容性。\n\n全部核心：使用所有可用的CPU核心（默认）。\n能效核心：仅使用能效/省电的CPU核心。\n自定义核心：手动指定要使用的CPU核心（以逗号分隔的数字）。\n\n注意：更改需要重启模拟器才能生效。</translation>
+    </message>
+    <message>
+      <source>Collect Shaders:\\nYou need this enabled to edit shaders with the debug menu (Ctrl + F10).</source>
+      <translation>收集着色器：\n启用此选项后可使用调试菜单（Ctrl + F10）编辑着色器。</translation>
+    </message>
+    <message>
+      <source>Console Language:\nSets the language that PS4 game uses.\nIt's recommended to set this to a language that the game supports, which will vary by region.</source>
+      <translation>控制台语言：\n设置PS4游戏使用的语言。\n建议设置为游戏支持的语言，不同地区可能有所不同。</translation>
+    </message>
+    <message>
+      <source>Copy GPU Buffers:\\nGets around race conditions involving GPU submits.\\nMay or may not help with PM4 type 0 crashes.</source>
+      <translation>复制GPU缓冲区：\n规避涉及GPU提交的竞态条件。\n可能对PM4类型0崩溃有帮助。</translation>
+    </message>
+    <message>
+      <source>Crash Diagnostics:\\nCreates a .yaml file with info about the Vulkan state at the time of crashing.\\nUseful for debugging 'Device lost' errors. If you have this enabled, you should enable Host AND Guest Debug Markers.\\nYou need Vulkan Validation Layers enabled and the Vulkan SDK for this to work.</source>
+      <translation>崩溃诊断：\n创建包含崩溃时Vulkan状态信息的.yaml文件。\n对调试"设备丢失"错误很有用。如果启用了此选项，还应启用主机和客户端调试标记。\n需要启用Vulkan验证层并安装Vulkan SDK才能使用此功能。</translation>
+    </message>
+    <message>
+      <source>Custom Cores</source>
+      <translation>自定义核心</translation>
+    </message>
+    <message>
+      <source>DLC Path:\\nThe folder where game DLC loaded from.</source>
+      <translation>DLC路径：\n加载游戏DLC的文件夹。</translation>
+    </message>
+    <message>
+      <source>Default tab when opening settings:\\nChoose which tab will open, the default is General.</source>
+      <translation>打开设置时的默认选项卡：\n选择默认打开的选项卡，默认为常规。</translation>
+    </message>
+    <message>
+      <source>Disable Trophy Pop-ups:\\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</source>
+      <translation>禁用奖杯弹窗：\n禁用游戏内奖杯通知。仍可通过奖杯查看器（在主窗口右键点击游戏）跟踪奖杯进度。</translation>
+    </message>
+    <message>
+      <source>Display Compatibility Data:\\nDisplays game compatibility information in table view. Enable \"Update Compatibility On Startup\" to get up-to-date information.</source>
+      <translation>显示兼容性数据：\n在表格视图中显示游戏兼容性信息。启用"启动时更新兼容性"以获取最新信息。</translation>
+    </message>
+    <message>
+      <source>Efficient Cores</source>
+      <translation>能效核心</translation>
+    </message>
+    <message>
+      <source>Enable Controller Background Input:\\nAllow shadPS4 to detect controller inputs when the game window is not in focus.</source>
+      <translation>启用控制器后台输入：\n允许shadPS4在游戏窗口不在焦点时检测控制器输入。</translation>
+    </message>
+    <message>
+      <source>Enable Debug Dumping:\\nSaves the import and export symbols and file header information of the currently running PS4 program to a directory.</source>
+      <translation>启用调试导出：\n将当前运行PS4程序的导入/导出符号和文件头信息保存到目录中。</translation>
+    </message>
+    <message>
+      <source>Enable Devkit Console Mode:\\nAdds support for Devkit console memory size.</source>
+      <translation>启用开发机模式：\n添加对开发机控制台内存大小的支持。</translation>
+    </message>
+    <message>
+      <source>Enable Direct Memory Access:\\nEnables arbitrary memory access from the GPU to CPU memory.</source>
+      <translation>启用直接内存访问：\n允许GPU到CPU内存的任意内存访问。</translation>
+    </message>
+    <message>
+      <source>Enable HDR:\\nEnables HDR in games that support it.\\nYour monitor must have support for the BT2020 PQ color space and the RGB10A2 swapchain format.</source>
+      <translation>启用HDR：\n在支持HDR的游戏中启用HDR。\n显示器必须支持BT2020 PQ色彩空间和RGB10A2交换链格式。</translation>
+    </message>
+    <message>
+      <source>Enable Logging:\\nEnables logging.\\nDo not change this if you do not know what you're doing!\\nWhen asking for help, make sure this setting is ENABLED.</source>
+      <translation>启用日志：\n启用日志记录。\n如果不清楚用途请勿修改！\n寻求帮助时，请确保此选项已启用。</translation>
+    </message>
+    <message>
+      <source>Enable Motion Controls:\\nWhen enabled it will use the controller's motion control if supported.</source>
+      <translation>启用手柄体感：\n如果支持，启用后将使用控制器的体感控制功能。</translation>
+    </message>
+    <message>
+      <source>Enable Null GPU:\\nFor the sake of technical debugging, disables game rendering as if there were no graphics card.</source>
+      <translation>启用空GPU：\n用于技术调试，禁用游戏渲染，模拟无显卡状态。</translation>
+    </message>
+    <message>
+      <source>Enable PS4 Neo Mode:\\nAdds support for PS4 Pro emulation and memory size. Currently causes instability in a large number of tested games.</source>
+      <translation>启用PS4 Neo模式：\n添加对PS4 Pro模拟和内存大小的支持。目前在许多测试游戏中会导致不稳定。</translation>
+    </message>
+    <message>
+      <source>Enable Readback Linear Images:\\nEnables async downloading of GPU modified linear images.\\nMight fix issues in some games.</source>
+      <translation>启用来回读取线性图像：\n启用GPU修改后线性图像的异步下载。\n可能修复某些游戏中的问题。</translation>
+    </message>
+    <message>
+      <source>Enable RenderDoc Debugging:\\nIf enabled, the emulator will provide compatibility with Renderdoc to allow capture and analysis of the currently rendered frame.</source>
+      <translation>启用RenderDoc调试：\n启用后，模拟器将提供RenderDoc兼容性，允许捕获和分析当前渲染的帧。</translation>
+    </message>
+    <message>
+      <source>Enable Shader Patching:\\nAutomatically enables and loads shader patches from the shader/patch folder.\\nPatches will be applied on launch without requiring manual activation via debug menu.</source>
+      <translation>启用着色器补丁：\n自动从shader/patch文件夹启用和加载着色器补丁。\n补丁将在启动时自动应用，无需通过调试菜单手动激活。</translation>
+    </message>
+    <message>
+      <source>Enable Shaders Dumping:\\nFor the sake of technical debugging, saves the games shaders to a folder as they render.</source>
+      <translation>启用着色器导出：\n用于技术调试，将游戏着色器在渲染时保存到文件夹中。</translation>
+    </message>
+    <message>
+      <source>Enable Vulkan Synchronization Validation:\\nEnables a system that validates the timing of Vulkan rendering tasks.\\nThis will reduce performance and likely change the behavior of emulation.\\nYou need the Vulkan SDK for this to work.</source>
+      <translation>启用Vulkan同步验证：\n启用验证Vulkan渲染任务时序的系统。\n这会降低性能并可能改变模拟行为。\n需要安装Vulkan SDK才能使用此功能。</translation>
+    </message>
+    <message>
+      <source>Enable Vulkan Validation Layers:\\nEnables a system that validates the state of the Vulkan renderer and logs information about its internal state.\\nThis will reduce performance and likely change the behavior of emulation.\\nYou need the Vulkan SDK for this to work.</source>
+      <translation>启用Vulkan验证层：\n启用验证Vulkan渲染器状态并记录其内部状态信息的系统。\n这会降低性能并可能改变模拟行为。\n需要安装Vulkan SDK才能使用此功能。</translation>
+    </message>
+    <message>
+      <source>Game Folders:\\nThe list of folders to check for installed games.</source>
+      <translation>游戏文件夹：\n用于检查已安装游戏的文件夹列表。</translation>
+    </message>
+    <message>
+      <source>Games directories</source>
+      <translation>游戏目录</translation>
+    </message>
+    <message>
+      <source>Global User Folder Created</source>
+      <translation>全局用户文件夹已创建</translation>
+    </message>
+    <message>
+      <source>Global User Folder Updated</source>
+      <translation>全局用户文件夹已更新</translation>
+    </message>
+    <message>
+      <source>Global folder exists</source>
+      <translation>全局文件夹已存在</translation>
+    </message>
+    <message>
+      <source>Global folder overwritten with portable data.</source>
+      <translation>全局文件夹已用便携数据覆盖。</translation>
+    </message>
+    <message>
+      <source>Graphics Device:\\nOn multiple GPU systems, select the GPU the emulator will use from the drop down list,\\nor select \"Auto Select\" to automatically determine it.</source>
+      <translation>图形设备：\n在多GPU系统中，从下拉列表中选择模拟器使用的GPU，\n或选择"自动选择"来自动确定。</translation>
+    </message>
+    <message>
+      <source>Guest Debug Markers:\\nInserts any debug markers the game itself has added to the command buffer.\\nIf you have this enabled, you should enable Crash Diagnostics.\\nUseful for programs like RenderDoc.</source>
+      <translation>客户端调试标记：\n插入游戏自身添加到命令缓冲区的所有调试标记。\n如果启用了此选项，还应启用崩溃诊断。\n对RenderDoc等工具有用。</translation>
+    </message>
+    <message>
+      <source>Hide Cursor:\\nChoose when the cursor will disappear:\\nNever: You will always see the mouse.\\nidle: Set a time for it to disappear after being idle.\\nAlways: you will never see the mouse.</source>
+      <translation>隐藏光标：\n选择光标何时消失：\n从不：始终显示鼠标。\n空闲时：设置空闲一段时间后隐藏。\n总是：始终不显示鼠标。</translation>
+    </message>
+    <message>
+      <source>Hide Description</source>
+      <translation>隐藏描述</translation>
+    </message>
+    <message>
+      <source>Hide Idle Cursor Timeout:\\nThe duration (seconds) after which the cursor that has been idle hides itself.</source>
+      <translation>空闲光标隐藏超时：\n光标空闲多长时间（秒）后自动隐藏。</translation>
+    </message>
+    <message>
+      <source>Host Debug Markers:\\nInserts emulator-side information like markers for specific AMDGPU commands around Vulkan commands, as well as giving resources debug names.\\nIf you have this enabled, you should enable Crash Diagnostics.\\nUseful for programs like RenderDoc.</source>
+      <translation>主机调试标记：\n在Vulkan命令周围插入模拟器侧信息，如特定AMDGPU命令的标记，以及为资源分配调试名称。\n如果启用了此选项，还应启用崩溃诊断。\n对RenderDoc等工具有用。</translation>
+    </message>
+    <message>
+      <source>Log Filter:\\nFilters the log to only print specific information.\\nExamples: \"Core:Trace\" \"Lib.Pad:Debug Common.Filesystem:Error\" \"*:Critical\"\\nLevels: Trace, Debug, Info, Warning, Error, Critical - in this order, a specific level silences all levels preceding it in the list and logs every level after it.</source>
+      <translation>日志过滤器：\n筛选日志仅输出特定信息。\n示例："Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical"\n级别：Trace, Debug, Info, Warning, Error, Critical - 按此顺序，指定级别会静默列表中该级别之前的所有级别，并记录该级别之后的所有级别。</translation>
+    </message>
+    <message>
+      <source>Log Type:\\nSets whether to synchronize the output of the log window for performance. May have adverse effects on emulation.</source>
+      <translation>日志类型：\n设置是否同步输出日志窗口以提高性能。可能对模拟产生不良影响。</translation>
+    </message>
+    <message>
+      <source>Microphone:\\nNone: Does not use the microphone.\\nDefault Device: Will use the default device defined in the system.\\nOr manually choose the microphone to be used from the list.</source>
+      <translation>麦克风：\n无：不使用麦克风。\n默认设备：使用系统中定义的默认设备。\n或从列表中手动选择要使用的麦克风。</translation>
+    </message>
+    <message>
+      <source>Moved data from global folder to:\n%1</source>
+      <translation>已将数据从全局文件夹移动到：\n%1</translation>
+    </message>
+    <message>
+      <source>Moved data from portable folder to:\n%1</source>
+      <translation>已将数据从便携文件夹移动到：\n%1</translation>
+    </message>
+    <message>
+      <source>Open Log Location:\\nOpen the folder where the log file is saved.</source>
+      <translation>打开日志位置：\n打开保存日志文件的文件夹。</translation>
+    </message>
+    <message>
+      <source>Open the custom trophy images/sounds folder:\\nYou can add custom images to the trophies and an audio.\\nAdd the files to custom_trophy with the following names:\\ntrophy.wav OR trophy.mp3, bronze.png, gold.png, platinum.png, silver.png\\nNote: The sound will only work in QT versions.</source>
+      <translation>打开自定义奖杯图片/音频文件夹：\n您可以添加自定义奖杯图片和音频。\n将以下命名的文件添加到custom_trophy文件夹：\ntrophy.wav 或 trophy.mp3、bronze.png、gold.png、platinum.png、silver.png\n注意：音频仅在Qt版本中有效。</translation>
+    </message>
+    <message>
+      <source>Play Title Music:\\nIf a game supports it, enable playing special music when selecting the game in the GUI.</source>
+      <translation>播放标题音乐：\n如果游戏支持，启用在GUI中选择游戏时播放特殊音乐。</translation>
+    </message>
+    <message>
+      <source>Portable User Folder Created</source>
+      <translation>便携用户文件夹已创建</translation>
+    </message>
+    <message>
+      <source>Portable User Folder Updated</source>
+      <translation>便携用户文件夹已更新</translation>
+    </message>
+    <message>
+      <source>Portable folder exists</source>
+      <translation>便携文件夹已存在</translation>
+    </message>
+    <message>
+      <source>Portable folder overwritten with global data.</source>
+      <translation>便携文件夹已用全局数据覆盖。</translation>
+    </message>
+    <message>
+      <source>Portable user folder:\\nStores shadPS4 settings and data that will be applied only to the shadPS4 build located in the current folder. Restart the app after creating the portable user folder to begin using it.</source>
+      <translation>便携用户文件夹：\n存储仅应用于当前文件夹中shadPS4构建版本的设置和数据。创建便携用户文件夹后需重新启动应用才能生效。</translation>
+    </message>
+    <message>
+      <source>Present Mode:\\nConfigures how video output will be presented to your screen.\\n\\n</source>
+      <translation>呈现模式：\n配置视频输出到屏幕的方式。\n\n</translation>
+    </message>
+    <message>
+      <source>Remove:\\nRemove a folder from the list.</source>
+      <translation>移除：
+从列表中移除文件夹。</translation>
+    </message>
+    <message>
+      <source>Revert</source>
+      <translation>Revert</translation>
+    </message>
+    <message>
+      <source>Save Data Path:\\nThe folder where game save data will be saved.</source>
+      <translation>存档数据路径：\n游戏存档数据的保存文件夹。</translation>
+    </message>
+    <message>
+      <source>Select the System Modules folder</source>
+      <translation>选择系统模块文件夹</translation>
+    </message>
+    <message>
+      <source>Separate Log Files:\\nWrites a separate logfile for each game.</source>
+      <translation>分离日志文件：\n为每个游戏写入单独的日志文件。</translation>
+    </message>
+    <message>
+      <source>Set Network Connected to True:\\nForces games to detect an active network connection. Actual online capabilities are not yet supported.</source>
+      <translation>设置网络连接为True：\n强制游戏检测到活动的网络连接。实际的在线功能尚未支持。</translation>
+    </message>
+    <message>
+      <source>ShadNet Accounts:\\nSign in each player to ShadNet using their NPID and password.\\nOnce signed in, the player's ShadNet online ID is used in place of their local username.</source>
+      <translation>ShadNet账户：\n使用NPID和密码登录ShadNet。\n登录后，玩家的ShadNet在线ID将替代本地用户名。</translation>
+    </message>
+    <message>
+      <source>ShadNet Network:\\nA PSN server replacement.\\nCompatibility is very limited at the moment.\\nYou can register at https://www.shadps4.net/shadNet/register/.</source>
+      <translation>ShadNet网络：\nPSN服务器替代方案。\n目前兼容性非常有限。\n可在 https://www.shadps4.net/shadNet/register/ 注册。</translation>
+    </message>
+    <message>
+      <source>Shadlix</source>
+      <translation>Shadlix</translation>
+    </message>
+    <message>
+      <source>Show Description</source>
+      <translation>显示描述</translation>
+    </message>
+    <message>
+      <source>Show Game Size In List:\\nThere is the size of the game in the list.</source>
+      <translation>在列表中显示游戏大小：\n在列表中显示游戏的大小。</translation>
+    </message>
+    <message>
+      <source>Trophy Key:\\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\\nMust contain only hex characters.</source>
+      <translation>奖杯密钥：\n用于解密奖杯的密钥。必须从越狱的PS4主机获取。\n只能包含十六进制字符。</translation>
+    </message>
+    <message>
+      <source>Update Compatibility Database:\\nImmediately update the compatibility database.</source>
+      <translation>更新兼容性数据库：\n立即更新兼容性数据库。</translation>
+    </message>
+    <message>
+      <source>Update Compatibility On Startup:\\nAutomatically update the compatibility database when shadPS4 starts.</source>
+      <translation>启动时更新兼容性：\n在shadPS4启动时自动更新兼容性数据库。</translation>
+    </message>
+    <message>
+      <source>Update:\\nRelease: Official versions released every month that may be very outdated, but are more reliable and tested.\\nNightly: Development versions that have all the latest features and fixes, but may contain bugs and are less stable.</source>
+      <translation>更新：
+正式版：每月发布的官方版本，可能较旧，但更可靠且经过测试。
+每夜构建版：包含所有最新功能和修复的开发版本，但可能包含错误且不太稳定。</translation>
+    </message>
+    <message>
+      <source>Username:\\nSets the PS4's account username, which may be displayed by some games.</source>
+      <translation>用户名：\n设置PS4账户用户名，某些游戏可能会显示。</translation>
+    </message>
+    <message>
+      <source>Vblank Frequency:\\nThe frame rate at which the emulator refreshes at (60hz is the baseline, whether the game runs at 30 or 60fps). Changing this may have adverse effects, such as increasing the game speed, or breaking critical game functionality that does not expect this to change!</source>
+      <translation>垂直空白频率：\n模拟器的刷新帧率（60Hz为基准，无论游戏运行在30还是60fps）。更改此设置可能产生不良效果，如加快游戏速度或破坏依赖固定刷新率的游戏功能！</translation>
+    </message>
+    <message>
+      <source>Volume:\\nAdjust volume for games on a global level, range goes from 0-300% with the default being 100%.</source>
+      <translation>音量：\n全局调整游戏音量，范围为0-300%，默认为100%。</translation>
+    </message>
+    <message>
+      <source>Width/Height:\\nSets the size of the emulator window at launch, which can be resized during gameplay.\\nThis is different from the in-game resolution.</source>
+      <translation>宽/高：\n设置模拟器启动时的窗口大小，游戏过程中可调整。\n此设置不同于游戏内分辨率。</translation>
+    </message>
+    <message>
+      <source>Enable Separate Update Folder</source>
+      <translation>启用独立更新文件夹</translation>
+    </message>
+    <message>
+      <source>Audio Backend</source>
+      <translation>音频后端</translation>
+    </message>
+    <message>
+      <source>Special Class 1</source>
+      <translation>特殊类型 1</translation>
+    </message>
+    <message>
+      <source>Special Class 2</source>
+      <translation>特殊类型 2</translation>
+    </message>
+    <message>
+      <source>Special Class 3</source>
+      <translation>特殊类型 3</translation>
+    </message>
+    <message>
+      <source>Special Class 4</source>
+      <translation>特殊类型 4</translation>
+    </message>
+    <message>
+      <source>Generate Portable folder Only</source>
+      <translation>仅生成便携文件夹</translation>
+    </message>
+    <message>
+      <source>Show Splash Screen</source>
+      <translation>显示启动画面</translation>
+    </message>
+    <message>
+      <source>SDL</source>
+      <translation>SDL</translation>
+    </message>
+    <message>
+      <source>OpenAL</source>
+      <translation>OpenAL</translation>
+    </message>
+    <message>
+      <source>Enable Auto Backups</source>
+      <translation>启用自动备份</translation>
+    </message>
+    <message>
+      <source>FPS Limit</source>
+      <translation>FPS限制</translation>
+    </message>
+    <message>
+      <source>Enable FPS Limiter</source>
+      <translation>启用FPS限制</translation>
+    </message>
+    <message>
+      <source>Player 1</source>
+      <translation>玩家1</translation>
+    </message>
+    <message>
+      <source>Player 2</source>
+      <translation>玩家2</translation>
+    </message>
+    <message>
+      <source>Player 3</source>
+      <translation>玩家3</translation>
+    </message>
+    <message>
+      <source>Player 4</source>
+      <translation>玩家4</translation>
+    </message>
+    <message>
+      <source>Special Pad Settings</source>
+      <translation>特殊手柄设置</translation>
+    </message>
+    <message>
+      <source>Enable Shader Cache</source>
+      <translation>启用着色器缓存</translation>
+    </message>
+    <message>
+      <source>Enable Cache Archive</source>
+      <translation>启用缓存归档</translation>
+    </message>
+    <message>
+      <source>Enable Shader Patching</source>
+      <translation>启用着色器补丁</translation>
+    </message>
+    <message>
+      <source>Game Volume</source>
+      <translation>游戏音量</translation>
+    </message>
+    <message>
+      <source>HTTP Host Override</source>
+      <translation>HTTP主机覆盖</translation>
+    </message>
+    <message>
+      <source>Enable DevKit Mode</source>
+      <translation>启用开发机模式</translation>
+    </message>
+    <message>
+      <source>Enable Neo Mode</source>
+      <translation>启用Neo模式</translation>
+    </message>
+    <message>
+      <source>Connected to Network</source>
+      <translation>已连接到网络</translation>
+    </message>
+    <message>
+      <source>Use Host Memory Fallback (System RAM as VRAM)</source>
+      <translation>使用主机内存回退（系统RAM作为VRAM）</translation>
+    </message>
+    <message>
+      <source>Memory Compression</source>
+      <translation>内存压缩</translation>
+    </message>
+    <message>
+      <source>Compression Level:</source>
+      <translation>压缩级别：</translation>
+    </message>
+    <message>
+      <source>Disabled</source>
+      <translation>已禁用</translation>
+    </message>
+    <message>
+      <source>Fast</source>
+      <translation>快速</translation>
+    </message>
+    <message>
+      <source>Balanced</source>
+      <translation>平衡</translation>
+    </message>
+    <message>
+      <source>Maximum</source>
+      <translation>最大</translation>
+    </message>
+    <message>
+      <source>Default</source>
+      <translation>默认</translation>
+    </message>
+    <message>
+      <source>Unsafe</source>
+      <translation>不安全</translation>
+    </message>
+    <message>
+      <source>Low</source>
+      <translation>低</translation>
+    </message>
+    <message>
+      <source>Disable FullScreen Tip on Boot</source>
+      <translation>启动时禁用全屏提示</translation>
+    </message>
+    <message>
+      <source>Enable Shader Skips</source>
+      <translation>启用着色器跳过</translation>
+    </message>
+    <message>
+      <source>Enable DMA</source>
+      <translation>启用DMA</translation>
+    </message>
+    <message>
+      <source>Emulator</source>
+      <translation>模拟器</translation>
+    </message>
+    <message>
+      <source>GUI Settings</source>
+      <translation>界面设置</translation>
+    </message>
+    <message>
+      <source>CPU Configuration</source>
+      <translation>CPU配置</translation>
+    </message>
+    <message>
+      <source>Custom CPU Cores (comma-separated):</source>
+      <translation>自定义CPU核心（逗号分隔）：</translation>
+    </message>
+    <message>
+      <source>Show Screenshot Notifications</source>
+      <translation>显示截图通知</translation>
+    </message>
+    <message>
+      <source>Usernames</source>
+      <translation>用户名</translation>
+    </message>
+    <message>
+      <source>Player 1 Enable</source>
+      <translation>启用玩家1</translation>
+    </message>
+    <message>
+      <source>Player 2 Enable</source>
+      <translation>启用玩家2</translation>
+    </message>
+    <message>
+      <source>Player 3 Enable</source>
+      <translation>启用玩家3</translation>
+    </message>
+    <message>
+      <source>Player 4 Enable</source>
+      <translation>启用玩家4</translation>
+    </message>
+    <message>
+      <source>Enable Players:</source>
+      <translation>启用玩家：</translation>
+    </message>
+    <message>
+      <source>ShadNet Network</source>
+      <translation>ShadNet网络</translation>
+    </message>
+    <message>
+      <source>Server</source>
+      <translation>服务器</translation>
+    </message>
+    <message>
+      <source>WebAPI Server</source>
+      <translation>WebAPI服务器</translation>
+    </message>
+    <message>
+      <source>Enable UPNP</source>
+      <translation>启用UPnP</translation>
+    </message>
+    <message>
+      <source>ShadNet Accounts</source>
+      <translation>ShadNet账户</translation>
+    </message>
+    <message>
+      <source>Sign In</source>
+      <translation>登录</translation>
+    </message>
+    <message>
+      <source>Account ID (NPID)</source>
+      <translation>账户ID（NPID）</translation>
+    </message>
+    <message>
+      <source>Password</source>
+      <translation>密码</translation>
+    </message>
+    <message>
+      <source>Show</source>
+      <translation>显示</translation>
+    </message>
+    <message>
+      <source>SysModules Folder</source>
+      <translation>系统模块文件夹</translation>
+    </message>
+    <message>
+      <source>User Folder Location</source>
+      <translation>用户文件夹位置</translation>
+    </message>
+    <message>
+      <source>Move Portable User folder to Appdata folder</source>
+      <translation>移动便携用户文件夹</translation>
+    </message>
+    <message>
+      <source>Enables PS/Home/Guide button Hardcoded Hotkeys</source>
+      <translation>启用PS/Home/Guide按钮：硬编码快捷键</translation>
+    </message>
+    <message>
+      <source>Disable Keyboard Bindings</source>
+      <translation>禁用键盘绑定</translation>
+    </message>
+    <message>
+      <source>Swap X/Circle Buttons (Xbox Layout)</source>
+      <translation>交换X/圆圈按钮（Xbox布局）</translation>
+    </message>
+    <message>
+      <source>Select memory compression level for better memory usage</source>
+      <translation>选择内存压缩级别以优化内存使用</translation>
+    </message>
+    <message>
+      <source>Disable Hardcoded Hotkeys</source>
+      <translation>禁用硬编码快捷键</translation>
+    </message>
+    <message>
+      <source>LinearImage Readbacks</source>
+      <translation>线性图像回读</translation>
+    </message>
+    <message>
+      <source>Readbacks Speed</source>
+      <translation>回读速度</translation>
+    </message>
+    <message>
+      <source>Select the readbacks speed mode</source>
+      <translation>选择回读速度模式</translation>
+    </message>
+    <message>
+      <source>Disable</source>
+      <translation>禁用</translation>
+    </message>
+    <message>
+      <source>Memory Allocation</source>
+      <translation>内存分配</translation>
+    </message>
+    <message>
+      <source>Signaling Info</source>
+      <translation>信令信息</translation>
+    </message>
+    <message>
+      <source>Player Enable/Disable</source>
+      <translation>玩家启用/禁用</translation>
+    </message>
   </context>
   <context>
     <name>TrophyViewer</name>
@@ -2456,7 +3503,6 @@
       <translation>显示隐藏奖杯</translation>
     </message>
   </context>
-
   <context>
     <name>VersionDialog</name>
     <message>
@@ -3297,12 +4343,1437 @@ Please select a new location.</source>
       <source>Are you sure you want to unregister this %1 version from the launcher?</source>
       <translation>确定要从启动器中注销此 %1 版本吗？</translation>
     </message>
+    <message>
+      <source>%1 version has been unregistered from the launcher </source>
+      <translation>%1 版本已从启动器中注销</translation>
+    </message>
+    <message>
+      <source>A folder with that name already exists.</source>
+      <translation>同名文件夹已存在。</translation>
+    </message>
+    <message>
+      <source>Download Complete</source>
+      <translation>下载完成</translation>
+    </message>
+    <message>
+      <source>Enter the name of this version as it appears in the list.</source>
+      <translation>请输入此版本在列表中显示的名称。</translation>
+    </message>
+    <message>
+      <source>Error</source>
+      <translation>错误</translation>
+    </message>
+    <message>
+      <source>Executable (*.exe)</source>
+      <translation>可执行文件 (*.exe)</translation>
+    </message>
+    <message>
+      <source>Executable does not exist:\n%1</source>
+      <translation>可执行文件不存在：\n%1</translation>
+    </message>
+    <message>
+      <source>Executable not found </source>
+      <translation>未找到可执行文件：</translation>
+    </message>
+    <message>
+      <source>Failed to copy executable.</source>
+      <translation>复制可执行文件失败。</translation>
+    </message>
+    <message>
+      <source>Failed to create folder.</source>
+      <translation>创建文件夹失败。</translation>
+    </message>
+    <message>
+      <source>Failed to delete folder.</source>
+      <translation>删除文件夹失败。</translation>
+    </message>
+    <message>
+      <source>Failed to determine the folder path.</source>
+      <translation>无法确定文件夹路径。</translation>
+    </message>
+    <message>
+      <source>Failed to fetch release info: </source>
+      <translation>获取发布信息失败：</translation>
+    </message>
+    <message>
+      <source>Failed to rename SDL executable:\n%1 → %2</source>
+      <translation>重命名SDL可执行文件失败：\n%1 → %2</translation>
+    </message>
+    <message>
+      <source>First you need to choose a location to save the </source>
+      <translation>您需要先选择一个位置来保存</translation>
+    </message>
+    <message>
+      <source>First you need to choose a location to save the versions </source>
+      <translation>您需要先选择一个位置来保存版本</translation>
+    </message>
+    <message>
+      <source>No version selected from Installed list.</source>
+      <translation>未从已安装列表中选择版本。</translation>
+    </message>
+    <message>
+      <source>No version selected from the Installed list.</source>
+      <translation>未从已安装列表中选择版本。</translation>
+    </message>
+    <message>
+      <source>No version selected.</source>
+      <translation>未选择版本。</translation>
+    </message>
+    <message>
+      <source>QT Version installed successfully. QT Check Enable\n</source>
+      <translation>Qt版本安装成功。已启用Qt检查\n</translation>
+    </message>
+    <message>
+      <source>Qt</source>
+      <translation>Qt</translation>
+    </message>
+    <message>
+      <source>Qt Version Selected</source>
+      <translation>已选择Qt版本</translation>
+    </message>
+    <message>
+      <source>SDL</source>
+      <translation>SDL</translation>
+    </message>
+    <message>
+      <source>SDL Version Selected</source>
+      <translation>已选择SDL版本</translation>
+    </message>
+    <message>
+      <source>SDL version installed successfully. SDL Check Enable\n</source>
+      <translation>SDL版本安装成功。已启用SDL检查\n</translation>
+    </message>
+    <message>
+      <source>Select UI type:</source>
+      <translation>选择界面类型：</translation>
+    </message>
+    <message>
+      <source>Select executable</source>
+      <translation>选择可执行文件</translation>
+    </message>
+    <message>
+      <source>Success</source>
+      <translation>成功</translation>
+    </message>
+    <message>
+      <source>The PKG Installer has been launched.\n</source>
+      <translation>PKG安装器已启动。\n</translation>
+    </message>
+    <message>
+      <source>The extraction process failed with exit </source>
+      <translation>解压过程失败，退出码：</translation>
+    </message>
+    <message>
+      <source>The extraction process timed out after 30 </source>
+      <translation>解压过程在30秒后超时</translation>
+    </message>
+    <message>
+      <source>The previously selected folder no longer exists.\n</source>
+      <translation>之前选择的文件夹已不存在。\n</translation>
+    </message>
+    <message>
+      <source>The previously selected folder no longer exists:\n%1\n\n</source>
+      <translation>之前选择的文件夹已不存在：\n%1\n\n</translation>
+    </message>
+    <message>
+      <source>To run the PKG installer, we need to download the %1 build (%2 </source>
+      <translation>要运行PKG安装器，需要下载 %1 构建版本 (%2 </translation>
+    </message>
+    <message>
+      <source>UI type</source>
+      <translation>界面类型</translation>
+    </message>
+    <message>
+      <source>Version added successfully.</source>
+      <translation>版本添加成功。</translation>
+    </message>
+    <message>
+      <source>Version name</source>
+      <translation>版本名称</translation>
+    </message>
+    <message>
+      <source>Version selected successfully:\n%1</source>
+      <translation>版本选择成功：\n%1</translation>
+    </message>
+    <message>
+      <source>Path to save versions</source>
+      <translation>版本保存路径</translation>
+    </message>
+    <message>
+      <source>Add Custom</source>
+      <translation>添加自定义</translation>
+    </message>
+    <message>
+      <source>Clear</source>
+      <translation>清空</translation>
+    </message>
+    <message>
+      <source>Installed</source>
+      <translation>已安装</translation>
+    </message>
+    <message>
+      <source>Date</source>
+      <translation>日期</translation>
+    </message>
+    <message>
+      <source>Repo</source>
+      <translation>仓库</translation>
+    </message>
+    <message>
+      <source>Full Path</source>
+      <translation>完整路径</translation>
+    </message>
+    <message>
+      <source>Check Changes (Refresh)</source>
+      <translation>检查更新（刷新）</translation>
+    </message>
+    <message>
+      <source>Delete</source>
+      <translation>删除</translation>
+    </message>
+    <message>
+      <source>Install Selected</source>
+      <translation>安装所选</translation>
+    </message>
+    <message>
+      <source>Uninstall Selected</source>
+      <translation>卸载所选</translation>
+    </message>
+    <message>
+      <source>Fetch SDL builds instead of Qt builds</source>
+      <translation>获取SDL构建版本（非Qt版本）</translation>
+    </message>
+    <message>
+      <source>Browse</source>
+      <translation>浏览</translation>
+    </message>
+    <message>
+      <source>Name</source>
+      <translation>名称</translation>
+    </message>
+    <message>
+      <source>Type</source>
+      <translation>类型</translation>
+    </message>
+    <message>
+      <source>Version</source>
+      <translation>版本</translation>
+    </message>
+    <message>
+      <source>Version Manager</source>
+      <translation>版本管理器</translation>
+    </message>
   </context>
   <context>
-    <name>KBMDialog</name>
+    <name>BigPictureWidget</name>
     <message>
       <source>Game Settings</source>
       <translation>游戏设置</translation>
+    </message>
+    <message>
+      <source>Hotkeys</source>
+      <translation>快捷键</translation>
+    </message>
+    <message>
+      <source>Mods Manager</source>
+      <translation>Mod管理器</translation>
+    </message>
+    <message>
+      <source>Play</source>
+      <translation>运行</translation>
+    </message>
+    <message>
+      <source>Quit</source>
+      <translation>退出</translation>
+    </message>
+    <message>
+      <source>Settings</source>
+      <translation>设置</translation>
+    </message>
+    <message>
+      <source>Arrow Left/Right</source>
+      <translation>左右箭头</translation>
+    </message>
+    <message>
+      <source>Arrow Down</source>
+      <translation>下箭头</translation>
+    </message>
+    <message>
+      <source>Arrow Up</source>
+      <translation>上箭头</translation>
+    </message>
+    <message>
+      <source>Shift + Arrow Up</source>
+      <translation>Shift + 上箭头</translation>
+    </message>
+    <message>
+      <source>Shift + N</source>
+      <translation>Shift + N</translation>
+    </message>
+    <message>
+      <source>Mute Background Music</source>
+      <translation>静音背景音乐</translation>
+    </message>
+    <message>
+      <source>Press - R - </source>
+      <translation>按 R 键</translation>
+    </message>
+    <message>
+      <source>Stop/Play Background Music</source>
+      <translation>停止/播放背景音乐</translation>
+    </message>
+    <message>
+      <source>Esc</source>
+      <translation>Esc</translation>
+    </message>
+    <message>
+      <source>Hotkeys &amp; Navigation Keys</source>
+      <translation>快捷键与导航键</translation>
+    </message>
+    <message>
+      <source>Arrow Up/Down</source>
+      <translation>上下箭头</translation>
+    </message>
+    <message>
+      <source>Arrow Right</source>
+      <translation>右箭头</translation>
+    </message>
+    <message>
+      <source>Arrow Left</source>
+      <translation>左箭头</translation>
+    </message>
+    <message>
+      <source>Backspace</source>
+      <translation>退格键</translation>
+    </message>
+    <message>
+      <source>Esc/Click on Fork Icon</source>
+      <translation>Esc/点击 Fork 图标</translation>
+    </message>
+  </context>
+  <context>
+    <name>GameDirectoryDialog</name>
+    <message>
+      <source>Browse</source>
+      <translation>浏览</translation>
+    </message>
+    <message>
+      <source>DLC Directory</source>
+      <translation>DLC目录</translation>
+    </message>
+    <message>
+      <source>Directory for system modules</source>
+      <translation>系统模块目录</translation>
+    </message>
+    <message>
+      <source>Error</source>
+      <translation>错误</translation>
+    </message>
+    <message>
+      <source>Games Directory</source>
+      <translation>游戏目录</translation>
+    </message>
+    <message>
+      <source>shadPS4 - Choose directory</source>
+      <translation>shadPS4 - 选择目录</translation>
+    </message>
+  </context>
+  <context>
+    <name>GameCinematicFrame</name>
+    <message>
+      <source>Play Game</source>
+      <translation>运行游戏</translation>
+    </message>
+    <message>
+      <source>Select a Game</source>
+      <translation>选择游戏</translation>
+    </message>
+  </context>
+  <context>
+    <name>GameSpecificDialog</name>
+    <message>
+      <source>Always</source>
+      <translation>总是</translation>
+    </message>
+    <message>
+      <source>Default Device</source>
+      <translation>默认设备</translation>
+    </message>
+    <message>
+      <source>Fifo (Vsync)</source>
+      <translation>Fifo（垂直同步）</translation>
+    </message>
+    <message>
+      <source>Idle</source>
+      <translation>空闲时</translation>
+    </message>
+    <message>
+      <source>Immediate (No Vsync)</source>
+      <translation>立即（无垂直同步）</translation>
+    </message>
+    <message>
+      <source>Mailbox (Vsync)</source>
+      <translation>Mailbox（垂直同步）</translation>
+    </message>
+    <message>
+      <source>Never</source>
+      <translation>从不</translation>
+    </message>
+    <message>
+      <source>async</source>
+      <translation>异步</translation>
+    </message>
+    <message>
+      <source>sync</source>
+      <translation>同步</translation>
+    </message>
+    <message>
+      <source>Audio Backend</source>
+      <translation>音频后端</translation>
+    </message>
+    <message>
+      <source>Special Class 1</source>
+      <translation>特殊类型 1</translation>
+    </message>
+    <message>
+      <source>Special Class 2</source>
+      <translation>特殊类型 2</translation>
+    </message>
+    <message>
+      <source>Special Class 3</source>
+      <translation>特殊类型 3</translation>
+    </message>
+    <message>
+      <source>Special Class 4</source>
+      <translation>特殊类型 4</translation>
+    </message>
+    <message>
+      <source>&amp;lt;b&amp;gt;Hint:&amp;lt;/b&amp;gt;&amp;lt;br/&amp;gt;
+												Extra Memory Allocation, you can set it from 1–9999. It adds that amount of memory to the emulator for usage and enables resolutions above 1440p.</source>
+      <translation>&amp;lt;b&amp;gt;提示：&amp;lt;/b&amp;gt;&amp;lt;br/&amp;gt;
+												Extra Memory Allocation, you can set it from 1–9999. It adds that amount of memory to the emulator for usage and enables resolutions above 1440p.</translation>
+    </message>
+    <message>
+      <source>300%</source>
+      <translation>300%</translation>
+    </message>
+    <message>
+      <source>Advanced</source>
+      <translation>高级</translation>
+    </message>
+    <message>
+      <source>Audio Device (DS4 speaker)</source>
+      <translation>音频设备（DS4 手柄扬声器）</translation>
+    </message>
+    <message>
+      <source>Audio Device (general)</source>
+      <translation>音频设备（通用）</translation>
+    </message>
+    <message>
+      <source>Balanced</source>
+      <translation>平衡</translation>
+    </message>
+    <message>
+      <source>Bottom</source>
+      <translation>底部</translation>
+    </message>
+    <message>
+      <source>Collect Shaders</source>
+      <translation>收集着色器</translation>
+    </message>
+    <message>
+      <source>Compression Level:</source>
+      <translation>压缩级别：</translation>
+    </message>
+    <message>
+      <source>Connected to Network</source>
+      <translation>已连接到网络</translation>
+    </message>
+    <message>
+      <source>Controller</source>
+      <translation>手柄</translation>
+    </message>
+    <message>
+      <source>Copy GPU Buffers</source>
+      <translation>复制 GPU 缓冲区</translation>
+    </message>
+    <message>
+      <source>Cursor</source>
+      <translation>光标</translation>
+    </message>
+    <message>
+      <source>Debug</source>
+      <translation>调试</translation>
+    </message>
+    <message>
+      <source>Default</source>
+      <translation>默认</translation>
+    </message>
+    <message>
+      <source>Disable</source>
+      <translation>禁用</translation>
+    </message>
+    <message>
+      <source>Disable FullScreen Tip on Boot</source>
+      <translation>启动时禁用全屏提示</translation>
+    </message>
+    <message>
+      <source>Disable Hardcoded Hotkeys</source>
+      <translation>禁用硬编码快捷键</translation>
+    </message>
+    <message>
+      <source>Disable Keyboard Bindings</source>
+      <translation>禁用键盘绑定</translation>
+    </message>
+    <message>
+      <source>Disable Trophy Notification</source>
+      <translation>禁用奖杯通知</translation>
+    </message>
+    <message>
+      <source>Disabled</source>
+      <translation>已禁用</translation>
+    </message>
+    <message>
+      <source>Display Mode</source>
+      <translation>显示模式</translation>
+    </message>
+    <message>
+      <source>Enable Auto Backups</source>
+      <translation>启用自动备份</translation>
+    </message>
+    <message>
+      <source>Enable Background Controller Input</source>
+      <translation>启用后台控制器输入</translation>
+    </message>
+    <message>
+      <source>Enable Cache Archive</source>
+      <translation>启用缓存归档</translation>
+    </message>
+    <message>
+      <source>Enable Crash Diagnostics</source>
+      <translation>启用崩溃诊断</translation>
+    </message>
+    <message>
+      <source>Enable DMA</source>
+      <translation>启用DMA</translation>
+    </message>
+    <message>
+      <source>Enable Debug Dumping</source>
+      <translation>启用调试转储</translation>
+    </message>
+    <message>
+      <source>Enable DevKit Mode</source>
+      <translation>启用开发机模式</translation>
+    </message>
+    <message>
+      <source>Enable Discord Rich Presence</source>
+      <translation>启用 Discord Rich Presence</translation>
+    </message>
+    <message>
+      <source>Enable FPS Limiter</source>
+      <translation>启用FPS限制</translation>
+    </message>
+    <message>
+      <source>Enable FSR</source>
+      <translation>启用 FSR</translation>
+    </message>
+    <message>
+      <source>Enable HDR</source>
+      <translation>启用 HDR</translation>
+    </message>
+    <message>
+      <source>Enable Logging</source>
+      <translation>启用日志记录</translation>
+    </message>
+    <message>
+      <source>Enable Mods</source>
+      <translation>启用Mod</translation>
+    </message>
+    <message>
+      <source>Enable Motion Controls</source>
+      <translation>启用体感控制</translation>
+    </message>
+    <message>
+      <source>Enable Neo Mode</source>
+      <translation>启用Neo模式</translation>
+    </message>
+    <message>
+      <source>Enable PS/Home/Guide button for Hotkeys</source>
+      <translation>启用PS/Home/Guide按钮作为快捷键</translation>
+    </message>
+    <message>
+      <source>Enable RCAS (sharpening)</source>
+      <translation>启用 RCAS（锐化）</translation>
+    </message>
+    <message>
+      <source>Enable RenderDoc Debugging</source>
+      <translation>启用 RenderDoc 调试</translation>
+    </message>
+    <message>
+      <source>Enable Shader Cache</source>
+      <translation>启用着色器缓存</translation>
+    </message>
+    <message>
+      <source>Enable Shader Patching</source>
+      <translation>启用着色器补丁</translation>
+    </message>
+    <message>
+      <source>Enable Shader Skips</source>
+      <translation>启用着色器跳过</translation>
+    </message>
+    <message>
+      <source>Enable Shaders Dumping</source>
+      <translation>启用着色器转储</translation>
+    </message>
+    <message>
+      <source>Enable Updates</source>
+      <translation>启用更新</translation>
+    </message>
+    <message>
+      <source>Enable Vulkan Synchronization Validation</source>
+      <translation>启用 Vulkan 同步验证</translation>
+    </message>
+    <message>
+      <source>Enable Vulkan Validation Layers</source>
+      <translation>启用 Vulkan 验证层</translation>
+    </message>
+    <message>
+      <source>Experimental</source>
+      <translation>实验性功能</translation>
+    </message>
+    <message>
+      <source>FPS Limit</source>
+      <translation>FPS限制</translation>
+    </message>
+    <message>
+      <source>FSR Settings</source>
+      <translation>FSR 设置</translation>
+    </message>
+    <message>
+      <source>Fast</source>
+      <translation>快速</translation>
+    </message>
+    <message>
+      <source>Fullscreen</source>
+      <translation>全屏</translation>
+    </message>
+    <message>
+      <source>Fullscreen (Borderless)</source>
+      <translation>无边框全屏</translation>
+    </message>
+    <message>
+      <source>Game</source>
+      <translation>游戏</translation>
+    </message>
+    <message>
+      <source>Game Volume</source>
+      <translation>游戏音量</translation>
+    </message>
+    <message>
+      <source>General</source>
+      <translation>常规</translation>
+    </message>
+    <message>
+      <source>Graphics</source>
+      <translation>图像</translation>
+    </message>
+    <message>
+      <source>Guest Debug Markers</source>
+      <translation>Guest 调试标记</translation>
+    </message>
+    <message>
+      <source>H:</source>
+      <translation>高：</translation>
+    </message>
+    <message>
+      <source>HTTP Host Override</source>
+      <translation>HTTP主机覆盖</translation>
+    </message>
+    <message>
+      <source>Hide Cursor</source>
+      <translation>隐藏光标</translation>
+    </message>
+    <message>
+      <source>Hide Cursor Idle Timeout</source>
+      <translation>光标隐藏闲置时长</translation>
+    </message>
+    <message>
+      <source>Host Debug Markers</source>
+      <translation>Host 调试标记</translation>
+    </message>
+    <message>
+      <source>Input</source>
+      <translation>输入</translation>
+    </message>
+    <message>
+      <source>Left</source>
+      <translation>左边</translation>
+    </message>
+    <message>
+      <source>LinearImage Readbacks</source>
+      <translation>线性图像回读</translation>
+    </message>
+    <message>
+      <source>Load Presets...</source>
+      <translation>加载预设……</translation>
+    </message>
+    <message>
+      <source>Log</source>
+      <translation>日志</translation>
+    </message>
+    <message>
+      <source>Log Filter</source>
+      <translation>日志过滤</translation>
+    </message>
+    <message>
+      <source>Log Type</source>
+      <translation>日志类型</translation>
+    </message>
+    <message>
+      <source>Logger</source>
+      <translation>日志</translation>
+    </message>
+    <message>
+      <source>Low</source>
+      <translation>低</translation>
+    </message>
+    <message>
+      <source>Maximum</source>
+      <translation>最大</translation>
+    </message>
+    <message>
+      <source>Memory Allocation</source>
+      <translation>内存分配</translation>
+    </message>
+    <message>
+      <source>Memory Compression</source>
+      <translation>内存压缩</translation>
+    </message>
+    <message>
+      <source>Mods Configuration</source>
+      <translation>Mod配置</translation>
+    </message>
+    <message>
+      <source>Notification Duration</source>
+      <translation>通知显示持续时间</translation>
+    </message>
+    <message>
+      <source>Open Log Location</source>
+      <translation>打开日志位置</translation>
+    </message>
+    <message>
+      <source>OpenAL</source>
+      <translation>OpenAL</translation>
+    </message>
+    <message>
+      <source>Player 1</source>
+      <translation>玩家1</translation>
+    </message>
+    <message>
+      <source>Player 2</source>
+      <translation>玩家2</translation>
+    </message>
+    <message>
+      <source>Player 3</source>
+      <translation>玩家3</translation>
+    </message>
+    <message>
+      <source>Player 4</source>
+      <translation>玩家4</translation>
+    </message>
+    <message>
+      <source>Present Mode</source>
+      <translation>呈现模式</translation>
+    </message>
+    <message>
+      <source>RCAS Attenuation:</source>
+      <translation>RCAS 衰减：</translation>
+    </message>
+    <message>
+      <source>Readbacks Speed</source>
+      <translation>回读速度</translation>
+    </message>
+    <message>
+      <source>Right</source>
+      <translation>右边</translation>
+    </message>
+    <message>
+      <source>SDL</source>
+      <translation>SDL</translation>
+    </message>
+    <message>
+      <source>Select memory compression level for better memory usage</source>
+      <translation>选择内存压缩级别以优化内存使用</translation>
+    </message>
+    <message>
+      <source>Select the readbacks speed mode</source>
+      <translation>选择回读速度模式</translation>
+    </message>
+    <message>
+      <source>Settings</source>
+      <translation>设置</translation>
+    </message>
+    <message>
+      <source>ShadNet Enabled</source>
+      <translation>已启用ShadNet</translation>
+    </message>
+    <message>
+      <source>Show Splash Screen</source>
+      <translation>显示启动画面</translation>
+    </message>
+    <message>
+      <source>Special Pad Settings</source>
+      <translation>特殊手柄设置</translation>
+    </message>
+    <message>
+      <source>Swap X/Circle Buttons (Xbox Layout)</source>
+      <translation>交换X/圆圈按钮（Xbox布局）</translation>
+    </message>
+    <message>
+      <source>Top</source>
+      <translation>顶部</translation>
+    </message>
+    <message>
+      <source>Trophy</source>
+      <translation>奖杯</translation>
+    </message>
+    <message>
+      <source>Trophy Notification Position</source>
+      <translation>奖杯通知位置</translation>
+    </message>
+    <message>
+      <source>Unsafe</source>
+      <translation>不安全</translation>
+    </message>
+    <message>
+      <source>Updates Configuration</source>
+      <translation>更新配置</translation>
+    </message>
+    <message>
+      <source>Use Host Memory Fallback (System RAM as VRAM)</source>
+      <translation>使用主机内存回退（系统RAM作为VRAM）</translation>
+    </message>
+    <message>
+      <source>Use Unified Input Config</source>
+      <translation>使用统一输入配置</translation>
+    </message>
+    <message>
+      <source>Vblank Frequency</source>
+      <translation>垂直消隐频率</translation>
+    </message>
+    <message>
+      <source>Video</source>
+      <translation>显示</translation>
+    </message>
+    <message>
+      <source>W:</source>
+      <translation>宽：</translation>
+    </message>
+    <message>
+      <source>Window Size</source>
+      <translation>窗口大小</translation>
+    </message>
+    <message>
+      <source>Windowed</source>
+      <translation>窗口</translation>
+    </message>
+    <message>
+      <source>localhost</source>
+      <translation>localhost</translation>
+    </message>
+  </context>
+  <context>
+    <name>VerticalGameActionsMenu</name>
+    <message>
+      <source>Cheats / Patches</source>
+      <translation>作弊码/补丁</translation>
+    </message>
+    <message>
+      <source>Delete Shader Cache</source>
+      <translation>删除着色器缓存</translation>
+    </message>
+    <message>
+      <source>Game Settings</source>
+      <translation>游戏设置</translation>
+    </message>
+    <message>
+      <source>Global Settings</source>
+      <translation>全局设置</translation>
+    </message>
+    <message>
+      <source>Launch &amp; Folders</source>
+      <translation>启动与文件夹</translation>
+    </message>
+    <message>
+      <source>Launch Game</source>
+      <translation>启动游戏</translation>
+    </message>
+    <message>
+      <source>Mods Manager</source>
+      <translation>Mod管理器</translation>
+    </message>
+    <message>
+      <source>Open Game Folder</source>
+      <translation>打开游戏文件夹</translation>
+    </message>
+    <message>
+      <source>Open Mods Folder</source>
+      <translation>打开Mod文件夹</translation>
+    </message>
+    <message>
+      <source>Open Update Folder</source>
+      <translation>打开更新文件夹</translation>
+    </message>
+    <message>
+      <source>Tools &amp; Config</source>
+      <translation>工具与配置</translation>
+    </message>
+  </context>
+  <context>
+    <name>HubMenuWidget</name>
+    <message>
+      <source>Hotkeys &amp; Navigation Keys</source>
+      <translation>快捷键与导航键</translation>
+    </message>
+    <message>
+      <source>Arrow Up/Down</source>
+      <translation>上下箭头</translation>
+    </message>
+    <message>
+      <source>Navigate Games/Buttons</source>
+      <translation>浏览游戏/按钮</translation>
+    </message>
+    <message>
+      <source>Arrow Right</source>
+      <translation>右箭头</translation>
+    </message>
+    <message>
+      <source>Focus on Buttons</source>
+      <translation>聚焦按钮</translation>
+    </message>
+    <message>
+      <source>Arrow Left</source>
+      <translation>左箭头</translation>
+    </message>
+    <message>
+      <source>Focus on Games</source>
+      <translation>聚焦游戏</translation>
+    </message>
+    <message>
+      <source>Enter/Space</source>
+      <translation>回车/空格</translation>
+    </message>
+    <message>
+      <source>Select/Play</source>
+      <translation>选择/运行</translation>
+    </message>
+    <message>
+      <source>Backspace</source>
+      <translation>退格键</translation>
+    </message>
+    <message>
+      <source>Hide/Show Games and Buttons</source>
+      <translation>隐藏/显示游戏和按钮</translation>
+    </message>
+    <message>
+      <source>Press - P - </source>
+      <translation>按 P 键</translation>
+    </message>
+    <message>
+      <source>Play Highlighted Game</source>
+      <translation>运行选中游戏</translation>
+    </message>
+    <message>
+      <source>Press - M - </source>
+      <translation>按 M 键</translation>
+    </message>
+    <message>
+      <source>Press - G - </source>
+      <translation>按 G 键</translation>
+    </message>
+    <message>
+      <source>Games Settings</source>
+      <translation>游戏设置</translation>
+    </message>
+    <message>
+      <source>Press - S - </source>
+      <translation>按 S 键</translation>
+    </message>
+    <message>
+      <source>Press - H - </source>
+      <translation>按 H 键</translation>
+    </message>
+    <message>
+      <source>Hotkeys Setup</source>
+      <translation>快捷键设置</translation>
+    </message>
+    <message>
+      <source>Esc/Click on Fork Icon</source>
+      <translation>Esc/点击 Fork 图标</translation>
+    </message>
+    <message>
+      <source>Exit</source>
+      <translation>退出</translation>
+    </message>
+  </context>
+  <context>
+    <name>WelcomeDialog</name>
+    <message>
+      <source>Close</source>
+      <translation>关闭</translation>
+    </message>
+    <message>
+      <source>Failed to move global folder to portable: %1</source>
+      <translation>移动全局文件夹到便携失败：%1</translation>
+    </message>
+    <message>
+      <source>Failed to move portable folder to global: %1</source>
+      <translation>移动便携文件夹到全局失败：%1</translation>
+    </message>
+    <message>
+      <source>Global Folder Set</source>
+      <translation>已设置全局文件夹</translation>
+    </message>
+    <message>
+      <source>Global Folder Successfully Set</source>
+      <translation>全局文件夹设置成功</translation>
+    </message>
+    <message>
+      <source>Global folder already exists.\n\nMove its content to portable?\n</source>
+      <translation>全局文件夹已存在。
+
+将其内容移动到便携文件夹？
+</translation>
+    </message>
+    <message>
+      <source>Global folder already exists.\n\nThis folder will be </source>
+      <translation>全局文件夹已存在。
+
+此文件夹将</translation>
+    </message>
+    <message>
+      <source>Global folder detected</source>
+      <translation>检测到全局文件夹</translation>
+    </message>
+    <message>
+      <source>Global folder with configuration already exists.\n\nMove its content to </source>
+      <translation>已有配置的全局文件夹。
+
+将其内容移动到</translation>
+    </message>
+    <message>
+      <source>Move Failed</source>
+      <translation>移动失败</translation>
+    </message>
+    <message>
+      <source>Portable Folder Set</source>
+      <translation>已设置便携文件夹</translation>
+    </message>
+    <message>
+      <source>Portable Folder Successfully Set</source>
+      <translation>便携文件夹设置成功</translation>
+    </message>
+    <message>
+      <source>Portable folder already exists.\n\nMove its content to global?\n</source>
+      <translation>便携文件夹已存在。
+
+将其内容移动到全局文件夹？
+</translation>
+    </message>
+    <message>
+      <source>Portable folder detected</source>
+      <translation>检测到便携文件夹</translation>
+    </message>
+    <message>
+      <source>Portable folder with configuration already exists.\n\nMove its content to </source>
+      <translation>已有配置的便携文件夹。
+
+将其内容移动到</translation>
+    </message>
+  </context>
+  <context>
+    <name>ModManagerDialog</name>
+    <message>
+      <source> Browse Nexus</source>
+      <translation> 浏览Nexus</translation>
+    </message>
+    <message>
+      <source>%1 - Details</source>
+      <translation>%1 - 详情</translation>
+    </message>
+    <message>
+      <source>(get it at nexusmods.com -&gt; your profile -&gt; API Keys):</source>
+      <translation>（在nexusmods.com -&gt; 个人资料 -&gt; API密钥中获取）：</translation>
+    </message>
+    <message>
+      <source>&lt; Prev</source>
+      <translation>&lt; 上一页</translation>
+    </message>
+    <message>
+      <source>Activate</source>
+      <translation>启用</translation>
+    </message>
+    <message>
+      <source>Active</source>
+      <translation>已启用</translation>
+    </message>
+    <message>
+      <source>Are you installing a folder or an archive?</source>
+      <translation>您要安装的是文件夹还是压缩包？</translation>
+    </message>
+    <message>
+      <source>Author</source>
+      <translation>作者</translation>
+    </message>
+    <message>
+      <source>Binary</source>
+      <translation>二进制</translation>
+    </message>
+    <message>
+      <source>Browse %1 Mods</source>
+      <translation>浏览 %1 的Mod</translation>
+    </message>
+    <message>
+      <source>Cancel</source>
+      <translation>取消</translation>
+    </message>
+    <message>
+      <source>Choose File to Download</source>
+      <translation>选择要下载的文件</translation>
+    </message>
+    <message>
+      <source>Close</source>
+      <translation>关闭</translation>
+    </message>
+    <message>
+      <source>Could not open the mods folder.</source>
+      <translation>无法打开Mod文件夹。</translation>
+    </message>
+    <message>
+      <source>Date Added</source>
+      <translation>添加日期</translation>
+    </message>
+    <message>
+      <source>Deactivate</source>
+      <translation>停用</translation>
+    </message>
+    <message>
+      <source>Details</source>
+      <translation>详情</translation>
+    </message>
+    <message>
+      <source>Download Started</source>
+      <translation>下载已开始</translation>
+    </message>
+    <message>
+      <source>Download link ready - opening in browser.</source>
+      <translation>下载链接已就绪 - 正在浏览器中打开。</translation>
+    </message>
+    <message>
+      <source>Empty</source>
+      <translation>空</translation>
+    </message>
+    <message>
+      <source>Error</source>
+      <translation>错误</translation>
+    </message>
+    <message>
+      <source>Extraction Failed</source>
+      <translation>解压失败</translation>
+    </message>
+    <message>
+      <source>Fetching download link...</source>
+      <translation>正在获取下载链接...</translation>
+    </message>
+    <message>
+      <source>Fetching file list...</source>
+      <translation>正在获取文件列表...</translation>
+    </message>
+    <message>
+      <source>File</source>
+      <translation>文件</translation>
+    </message>
+    <message>
+      <source>File Structure:</source>
+      <translation>文件结构：</translation>
+    </message>
+    <message>
+      <source>Folder</source>
+      <translation>文件夹</translation>
+    </message>
+    <message>
+      <source>General</source>
+      <translation>通用</translation>
+    </message>
+    <message>
+      <source>Get Download Link</source>
+      <translation>获取下载链接</translation>
+    </message>
+    <message>
+      <source>Grid</source>
+      <translation>网格</translation>
+    </message>
+    <message>
+      <source>Image</source>
+      <translation>图片</translation>
+    </message>
+    <message>
+      <source>Inactive</source>
+      <translation>未启用</translation>
+    </message>
+    <message>
+      <source>Install Mod</source>
+      <translation>安装Mod</translation>
+    </message>
+    <message>
+      <source>Installed Mods</source>
+      <translation>已安装的Mod</translation>
+    </message>
+    <message>
+      <source>Key validated. Type a mod name and hit Search.</source>
+      <translation>密钥已验证。输入Mod名称并点击搜索。</translation>
+    </message>
+    <message>
+      <source>List</source>
+      <translation>列表</translation>
+    </message>
+    <message>
+      <source>Loading...</source>
+      <translation>加载中...</translation>
+    </message>
+    <message>
+      <source>Mod Conflict Detected</source>
+      <translation>检测到Mod冲突</translation>
+    </message>
+    <message>
+      <source>Mod Deactivation Complete</source>
+      <translation>Mod停用完成</translation>
+    </message>
+    <message>
+      <source>Mod Deactivation Warning</source>
+      <translation>Mod停用警告</translation>
+    </message>
+    <message>
+      <source>Mod Exists</source>
+      <translation>Mod已存在</translation>
+    </message>
+    <message>
+      <source>Mod Information:</source>
+      <translation>Mod信息：</translation>
+    </message>
+    <message>
+      <source>Mod Not Found</source>
+      <translation>未找到Mod</translation>
+    </message>
+    <message>
+      <source>Mods (*.zip *.rar *.7z *.tar *.gz *.tgz);;All Files (*.*)</source>
+      <translation>Mod压缩包 (*.zip *.rar *.7z *.tar *.gz *.tgz);;所有文件 (*.*)</translation>
+    </message>
+    <message>
+      <source>Name</source>
+      <translation>名称</translation>
+    </message>
+    <message>
+      <source>Next &gt;</source>
+      <translation>下一页 &gt;</translation>
+    </message>
+    <message>
+      <source>Nexus API key: [OK] (connected)</source>
+      <translation>Nexus API密钥：[正常]（已连接）</translation>
+    </message>
+    <message>
+      <source>Nexus API key: [X] invalid - please check your key</source>
+      <translation>Nexus API密钥：[✕] 无效 - 请检查您的密钥</translation>
+    </message>
+    <message>
+      <source>Nexus API key: not set - paste your key to enable search</source>
+      <translation>Nexus API密钥：未设置 - 粘贴密钥以启用搜索</translation>
+    </message>
+    <message>
+      <source>Nexus Mods API Key</source>
+      <translation>Nexus Mods API密钥</translation>
+    </message>
+    <message>
+      <source>Nexus Mods Error</source>
+      <translation>Nexus Mods错误</translation>
+    </message>
+    <message>
+      <source>Nexus did not return a download link.\n</source>
+      <translation>Nexus未返回下载链接。
+</translation>
+    </message>
+    <message>
+      <source>No Files</source>
+      <translation>无文件</translation>
+    </message>
+    <message>
+      <source>No Link</source>
+      <translation>无链接</translation>
+    </message>
+    <message>
+      <source>No files</source>
+      <translation>无文件</translation>
+    </message>
+    <message>
+      <source>No image</source>
+      <translation>无图片</translation>
+    </message>
+    <message>
+      <source>No mods found for that query.</source>
+      <translation>未找到匹配的Mod。</translation>
+    </message>
+    <message>
+      <source>OK</source>
+      <translation>确定</translation>
+    </message>
+    <message>
+      <source>Once the file is saved, use the \"Install Mod\" button\n</source>
+      <translation>文件保存后，请使用“安装Mod”按钮
+</translation>
+    </message>
+    <message>
+      <source>Open Folder</source>
+      <translation>打开文件夹</translation>
+    </message>
+    <message>
+      <source>Open on Nexus</source>
+      <translation>在Nexus打开</translation>
+    </message>
+    <message>
+      <source>Paste your Nexus Mods personal API key\n</source>
+      <translation>粘贴您的Nexus Mods个人API密钥
+</translation>
+    </message>
+    <message>
+      <source>Path</source>
+      <translation>路径</translation>
+    </message>
+    <message>
+      <source>Please enter a search term.</source>
+      <translation>请输入搜索词。</translation>
+    </message>
+    <message>
+      <source>Please unpack the RAR archive manually and install the mod as a folder, </source>
+      <translation>请手动解压RAR文件并以文件夹形式安装Mod，</translation>
+    </message>
+    <message>
+      <source>RAR Not Supported</source>
+      <translation>不支持RAR格式</translation>
+    </message>
+    <message>
+      <source>RAR archives are not supported for mod installation on Windows.\n</source>
+      <translation>Windows上不支持RAR格式的Mod安装。
+</translation>
+    </message>
+    <message>
+      <source>Refresh</source>
+      <translation>刷新</translation>
+    </message>
+    <message>
+      <source>Remove Mod</source>
+      <translation>移除Mod</translation>
+    </message>
+    <message>
+      <source>Remove functionality needs to be adapted for the new UI system.</source>
+      <translation>移除功能需要适配新的UI系统。</translation>
+    </message>
+    <message>
+      <source>Search</source>
+      <translation>搜索</translation>
+    </message>
+    <message>
+      <source>Search mods...</source>
+      <translation>搜索Mod...</translation>
+    </message>
+    <message>
+      <source>Searching Nexus...</source>
+      <translation>正在搜索Nexus...</translation>
+    </message>
+    <message>
+      <source>Select Mod</source>
+      <translation>选择Mod</translation>
+    </message>
+    <message>
+      <source>Select Mod Archive</source>
+      <translation>选择Mod压缩包</translation>
+    </message>
+    <message>
+      <source>Select Mod Folder</source>
+      <translation>选择Mod文件夹</translation>
+    </message>
+    <message>
+      <source>Set API Key</source>
+      <translation>设置API密钥</translation>
+    </message>
+    <message>
+      <source>Size</source>
+      <translation>大小</translation>
+    </message>
+    <message>
+      <source>Text</source>
+      <translation>文本</translation>
+    </message>
+    <message>
+      <source>The download has been opened in your browser.\n\n</source>
+      <translation>下载链接已在浏览器中打开。
+
+</translation>
+    </message>
+    <message>
+      <source>The mod page will open in your browser instead.</source>
+      <translation>Mod页面将在浏览器中打开。</translation>
+    </message>
+    <message>
+      <source>This mod already exists.</source>
+      <translation>此Mod已存在。</translation>
+    </message>
+    <message>
+      <source>This mod conflicts with following active mods:\n\n</source>
+      <translation>此Mod与以下已启用的Mod冲突：
+
+</translation>
+    </message>
+    <message>
+      <source>This mod has no downloadable files listed on Nexus.</source>
+      <translation>此Mod在Nexus上没有列出可下载的文件。</translation>
+    </message>
+    <message>
+      <source>This sometimes happens for free-tier accounts.\n</source>
+      <translation>免费账户偶尔会出现此情况。
+</translation>
+    </message>
+    <message>
+      <source>Type</source>
+      <translation>类型</translation>
+    </message>
+    <message>
+      <source>Unable to extract the mod archive.</source>
+      <translation>无法解压Mod压缩包。</translation>
+    </message>
+    <message>
+      <source>Unknown</source>
+      <translation>未知</translation>
+    </message>
+    <message>
+      <source>Validating key...</source>
+      <translation>正在验证密钥...</translation>
+    </message>
+    <message>
+      <source>[DL] Get Files</source>
+      <translation>[下载] 获取文件</translation>
+    </message>
+    <message>
+      <source>\nActivating this mod will overwrite conflicting files. Continue?</source>
+      <translation>
+启用此Mod将覆盖冲突的文件。是否继续？</translation>
+    </message>
+    <message>
+      <source>by %1</source>
+      <translation>作者：%1</translation>
+    </message>
+    <message>
+      <source>on the \"Installed Mods\" tab to add it to your game.</source>
+      <translation>在“已安装的Mod”选项卡中将其添加到您的游戏。</translation>
     </message>
   </context>
 </TS>

--- a/src/qt_gui/translations/zh_CN.ts
+++ b/src/qt_gui/translations/zh_CN.ts
@@ -3475,6 +3475,60 @@
       <source>Player Enable/Disable</source>
       <translation>玩家启用/禁用</translation>
     </message>
+    <message>
+      <source>
+        &lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
+        Enable this for High Resolution Patches&lt;br/&gt;
+        Can cause issues on other games.&lt;br/&gt;
+        Disable if you can't boot other games.
+        </source>
+      <translation>&lt;b&gt;提示：&lt;/b&gt;&lt;br/&gt;启用此项可使用高分辨率补丁&lt;br/&gt;可能导致其他游戏出现问题。&lt;br/&gt;如果无法启动其他游戏请禁用。</translation>
+    </message>
+    <message>
+      <source>
+        &lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
+        Helps inFamous crash on binaryinfo crash,&lt;br/&gt;
+		Driveclub slowdowns,&lt;br/&gt;
+		and COD Ghost boot to main menu and some stages.&lt;br/&gt;		
+        </source>
+      <translation>&lt;b&gt;提示：&lt;/b&gt;&lt;br/&gt;有助于解决inFamous的binaryinfo崩溃、Driveclub的掉帧问题，以及COD Ghost启动到主菜单和某些关卡。</translation>
+    </message>
+    <message>
+      <source>
+        &lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
+        DMA implementation.&lt;br/&gt;
+        Disable this for TLG; disabling helps with random crashes.&lt;br/&gt;
+        </source>
+      <translation>&lt;b&gt;提示：&lt;/b&gt;&lt;br/&gt;DMA实现，玩TLG时请禁用，可减少随机崩溃。</translation>
+    </message>
+    <message>
+      <source>
+        &lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
+        Linear Readbacks for Postprocessing, helps TLG.&lt;br/&gt;
+		Disable for Elden Ring.&lt;br/&gt;
+        Disable if you encounter issues.&lt;br/&gt;
+		Enable if you get driver restart on DRIVECLUB.&lt;br/&gt;       
+        </source>
+      <translation>&lt;b&gt;提示：&lt;/b&gt;&lt;br/&gt;用于后处理的线性回读，有助于TLG。玩艾尔登法环时请禁用。遇到问题时请禁用。玩DRIVECLUB时如果显卡驱动重启请启用</translation>
+    </message>
+    <message>
+      <source>
+&lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
+Disable – Disable readbacks&lt;br/&gt;
+Unsafe – Old Fast Readbacks Speed - If day races dosent show brighness on Driveclub reload Event&lt;br/&gt;
+Low – Low readbacks Speed (Most Accurate)&lt;br/&gt;
+Default – Normal Readbacks Speed&lt;br/&gt;
+Fast – Fast readbacks Speed - If day races dosent show brighness on Driveclub reload Event&lt;br/&gt;
+                </source>
+      <translation>&lt;b&gt;提示：&lt;/b&gt;&lt;br/&gt;禁用 - 禁用回读&lt;br/&gt;不安全 - 旧版快速回读速度&lt;br/&gt;低 - 最精确的回读&lt;br/&gt;默认 - 正常回读速度&lt;br/&gt;快速 - 最快回读速度</translation>
+    </message>
+    <message>
+      <source>
+												&lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
+												Extra Memory Allocation, you can set it from 1–9999. It adds that amount of memory to the emulator for usage and enables resolutions above 1440p.
+											</source>
+      <translation>&lt;b&gt;提示：&lt;/b&gt;&lt;br/&gt;额外内存分配，可设置1-9999。为模拟器增加对应数量的内存，并启用高于1440p的分辨率。</translation>
+    </message>
   </context>
   <context>
     <name>TrophyViewer</name>
@@ -4748,12 +4802,6 @@ Please select a new location.</source>
       <translation>特殊类型 4</translation>
     </message>
     <message>
-      <source>&amp;lt;b&amp;gt;Hint:&amp;lt;/b&amp;gt;&amp;lt;br/&amp;gt;
-												Extra Memory Allocation, you can set it from 1–9999. It adds that amount of memory to the emulator for usage and enables resolutions above 1440p.</source>
-      <translation>&amp;lt;b&amp;gt;提示：&amp;lt;/b&amp;gt;&amp;lt;br/&amp;gt;
-												Extra Memory Allocation, you can set it from 1–9999. It adds that amount of memory to the emulator for usage and enables resolutions above 1440p.</translation>
-    </message>
-    <message>
       <source>300%</source>
       <translation>300%</translation>
     </message>
@@ -5180,6 +5228,70 @@ Please select a new location.</source>
     <message>
       <source>localhost</source>
       <translation>localhost</translation>
+    </message>
+    <message>
+      <source>
+
+												&lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
+												Enable this for High Resolution Patches&lt;br/&gt;
+												Can cause issues on other games.&lt;br/&gt;
+												Disable if you cant boot other games.
+
+											</source>
+      <translation>&lt;b&gt;提示：&lt;/b&gt;&lt;br/&gt;启用此项可使用高分辨率补丁&lt;br/&gt;可能导致其他游戏出现问题。&lt;br/&gt;如果无法启动其他游戏请禁用。</translation>
+    </message>
+    <message>
+      <source>
+
+												&lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
+												Helps inFamous crash on binaryinfo crash,
+												Driveclub slowdowns,
+												and COD Ghost boot to main menu and some stages.&lt;br/&gt;
+
+											</source>
+      <translation>&lt;b&gt;提示：&lt;/b&gt;&lt;br/&gt;有助于解决inFamous的binaryinfo崩溃、Driveclub的掉帧问题，以及COD Ghost启动到主菜单和某些关卡。</translation>
+    </message>
+    <message>
+      <source>
+
+												&lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
+												DMA implementation,
+												Disable this for TLG, disabling help with random crashes.&lt;br/&gt;
+
+											</source>
+      <translation>&lt;b&gt;提示：&lt;/b&gt;&lt;br/&gt;DMA实现，玩TLG时请禁用，可减少随机崩溃。</translation>
+    </message>
+    <message>
+      <source>
+
+												&lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
+												Linear Readbacks for Postprocessing, helps TLG
+												Disable for Elden Ring.
+												Disable if encounter issues
+												Enable if you get Driver restart on DRIVECLUB&lt;br/&gt;
+
+											</source>
+      <translation>&lt;b&gt;提示：&lt;/b&gt;&lt;br/&gt;用于后处理的线性回读，有助于TLG。玩艾尔登法环时请禁用。遇到问题时请禁用。玩DRIVECLUB时如果显卡驱动重启请启用</translation>
+    </message>
+    <message>
+      <source>
+
+												&lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
+												Disable – Disable readbacks&lt;br/&gt;
+												Unsafe – Old Fast Readbacks Speed - If day races dosent show brighness on Driveclub reload Event&lt;br/&gt;
+												Low – Low readbacks Speed (Most Accurate)&lt;br/&gt;
+												Default – Normal Readbacks Speed&lt;br/&gt;
+												Fast – Fast readbacks Speed - If day races dosent show brighness on Driveclub reload Event&lt;br/&gt;
+
+											</source>
+      <translation>&lt;b&gt;提示：&lt;/b&gt;&lt;br/&gt;禁用 - 禁用回读&lt;br/&gt;不安全 - 旧版快速回读速度&lt;br/&gt;低 - 最精确的回读&lt;br/&gt;默认 - 正常回读速度&lt;br/&gt;快速 - 最快回读速度</translation>
+    </message>
+    <message>
+      <source>
+												&lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
+												Extra Memory Allocation, you can set it from 1–9999. It adds that amount of memory to the emulator for usage and enables resolutions above 1440p.
+											</source>
+      <translation>&lt;b&gt;提示：&lt;/b&gt;&lt;br/&gt;额外内存分配，可设置1-9999。为模拟器增加对应数量的内存，并启用高于1440p的分辨率。</translation>
     </message>
   </context>
   <context>


### PR DESCRIPTION
Thanks for merging #143! It's my honor to contribute to this well-maintained fork. I've enjoyed Bloodborne for several days :D

While using the emulator I noticed many UI strings were still in English. To make review easier, I've split the fixes into three independent PRs.

**This PR covers the translation file itself.**

## Changes
- 1 file: 
- 26 translation contexts, all entries fully translated
- Context names aligned with actual C++ class names
- Zero type="unfinished" entries remaining

## Tested
- CI build: test/ts-and-tr (this PR + #146)

## Related
Part of a 3-PR series: #146 · #147

Dev history: https://github.com/Moodow/shadPS4/commits/fix/zh-cn-translation-coverage