### PR TITLE
i18n: remove notr=true from Hint strings in .ui files

### DIFF
--- a/src/qt_gui/game_specific_dialog.ui
+++ b/src/qt_gui/game_specific_dialog.ui
@@ -721,7 +721,7 @@
 																					<enum>QAbstractSpinBox::ButtonSymbols::UpDownArrows</enum>
 																				</property>
 																				<property name="suffix">
-																					<string notr="true"/>
+																					<string/>
 																				</property>
 																				<property name="maximum">
 																					<number>3600</number>
@@ -1589,7 +1589,7 @@
 											</font>
 										</property>
 										<property name="text">
-											<string notr="true">
+											<string>
 
 												&lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
 												Enable this for High Resolution Patches&lt;br/&gt;
@@ -1702,7 +1702,7 @@
 											</font>
 										</property>
 										<property name="text">
-											<string notr="true">
+											<string>
 
 												&lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
 												Helps inFamous crash on binaryinfo crash,
@@ -1732,7 +1732,7 @@
 											</font>
 										</property>
 										<property name="text">
-											<string notr="true">
+											<string>
 
 												&lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
 												DMA implementation,
@@ -1758,7 +1758,7 @@
 											</font>
 										</property>
 										<property name="text">
-											<string notr="true">
+											<string>
 
 												&lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
 												Linear Readbacks for Postprocessing, helps TLG
@@ -1836,7 +1836,7 @@
 											</font>
 										</property>
 										<property name="text">
-											<string notr="true">
+											<string>
 
 												&lt;b&gt;Hint:&lt;/b&gt;&lt;br/&gt;
 												Disable – Disable readbacks&lt;br/&gt;

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -2284,7 +2284,7 @@
 																					<enum>QAbstractSpinBox::ButtonSymbols::UpDownArrows</enum>
 																				</property>
 																				<property name="suffix">
-																					<string notr="true"/>
+																					<string/>
 																				</property>
 																				<property name="maximum">
 																					<number>3600</number>
@@ -3083,7 +3083,7 @@
 										<property name="alignment">
 										</property>
 										<property name="text">
-											<string notr="true">
+											<string>
 												<![CDATA[
         <b>Hint:</b><br/>
         Enable this for High Resolution Patches<br/>
@@ -3193,7 +3193,7 @@
 										<property name="alignment">
 										</property>
 										<property name="text">
-											<string notr="true">
+											<string>
 												<![CDATA[
         <b>Hint:</b><br/>
         Helps inFamous crash on binaryinfo crash,<br/>
@@ -3238,7 +3238,7 @@
 											</font>
 										</property>
 										<property name="text">
-											<string notr="true">
+											<string>
 												<![CDATA[
         <b>Hint:</b><br/>
         DMA implementation.<br/>
@@ -3265,7 +3265,7 @@
 											</font>
 										</property>
 										<property name="text">
-											<string notr="true">
+											<string>
 												<![CDATA[
         <b>Hint:</b><br/>
         Linear Readbacks for Postprocessing, helps TLG.<br/>
@@ -3334,7 +3334,7 @@
 											</font>
 										</property>
 										<property name="text">
-											<string notr="true">
+											<string>
 												<![CDATA[
 <b>Hint:</b><br/>
 Disable – Disable readbacks<br/>


### PR DESCRIPTION
Part of a 3-PR series (see #145). Benefits all languages, not just zh-CN.

## Summary
Based on #145, removes the notr="true" attribute from Hint tooltip strings in .ui files.

## Background
Qt Designer automatically adds notr="true" to strings containing HTML markup. I'm not sure if this was an intentional decision or Qt Designer's default — if the latter, this PR can be safely merged; if the former (e.g. the technical hint content was deliberately kept untranslated), feel free to skip. The translations are already in #145's zh_CN.ts.

## Changes
- 2 files: game_specific_dialog.ui, settings_dialog.ui
- Attribute-only changes, no UI structure or layout modified

## Tested
- CI build: test/ts-tr-notr (all 3 PRs combined)

## Related
Part of a 3-PR series: #145 · #146

Dev history: https://github.com/Moodow/shadPS4/commits/fix/zh-cn-translation-coverage